### PR TITLE
fix: make libraries buildable

### DIFF
--- a/libs/is-steamid-validator/package.json
+++ b/libs/is-steamid-validator/package.json
@@ -1,0 +1,3 @@
+{
+  "name": "@tf2-automatic/is-steamid-validator"
+}

--- a/libs/is-steamid-validator/project.json
+++ b/libs/is-steamid-validator/project.json
@@ -24,6 +24,17 @@
           "codeCoverage": true
         }
       }
+    },
+    "build": {
+      "executor": "@nrwl/js:tsc",
+      "outputs": ["{options.outputPath}"],
+      "options": {
+        "outputPath": "dist/libs/is-steamid-validator",
+        "tsConfig": "libs/is-steamid-validator/tsconfig.lib.json",
+        "packageJson": "libs/is-steamid-validator/package.json",
+        "main": "libs/is-steamid-validator/src/index.ts",
+        "assets": ["libs/is-steamid-validator/*.md"]
+      }
     }
   },
   "tags": []

--- a/libs/nestjs-steamid-pipe/package.json
+++ b/libs/nestjs-steamid-pipe/package.json
@@ -1,0 +1,3 @@
+{
+  "name": "@tf2-automatic/is-steamid-pipe"
+}

--- a/libs/nestjs-steamid-pipe/project.json
+++ b/libs/nestjs-steamid-pipe/project.json
@@ -24,6 +24,17 @@
           "codeCoverage": true
         }
       }
+    },
+    "build": {
+      "executor": "@nrwl/js:tsc",
+      "outputs": ["{options.outputPath}"],
+      "options": {
+        "outputPath": "dist/libs/is-steamid-pipe",
+        "tsConfig": "libs/is-steamid-pipe/tsconfig.lib.json",
+        "packageJson": "libs/is-steamid-pipe/package.json",
+        "main": "libs/is-steamid-pipe/src/index.ts",
+        "assets": ["libs/is-steamid-pipe/*.md"]
+      }
     }
   },
   "tags": []


### PR DESCRIPTION
Because bot-data uses is-steamid-validator, is-steamid-validator needs to be built