### PR TITLE
fix(bot): storage on shutdown wait in correct order

### DIFF
--- a/apps/bot/src/storage/storage.service.ts
+++ b/apps/bot/src/storage/storage.service.ts
@@ -42,7 +42,7 @@ export class StorageService implements OnApplicationShutdown {
 
   onApplicationShutdown() {
     // Wait for all writes to finish
-    return Promise.all(Array.from(this.nextWrites.values()).map((write) => write.promise)
+    return Promise.all(Array.from(this.nextWrites.values()).map((write) => write.promise))
       .then(() => {
         return Promise.all(this.currentWrites.values());
       })


### PR DESCRIPTION
First wait for next, then wait for current, and then to be sure, wait for the queue to be empty.