### PR TITLE
feat(bot-manager): inventory queue

### DIFF
--- a/apps/bot-manager/src/common/utils/backoff-strategy.ts
+++ b/apps/bot-manager/src/common/utils/backoff-strategy.ts
@@ -1,0 +1,23 @@
+import { RetryOptions } from '@tf2-automatic/bot-manager-data';
+import { MinimalJob } from 'bullmq';
+
+type BackoffStrategy = (
+  attemptsMade: number,
+  job: MinimalJob<{ retry?: RetryOptions }>
+) => number;
+
+export const customBackoffStrategy: BackoffStrategy = (attempts, job) => {
+  const strategy = job.data.retry?.strategy ?? 'exponential';
+  const delay = job.data.retry?.delay ?? 1000;
+  const maxDelay = job.data.retry?.maxDelay ?? 10000;
+
+  let wait = delay;
+
+  if (strategy === 'exponential') {
+    wait = 2 ** (attempts - 1) * delay;
+  } else if (strategy === 'linear') {
+    wait = attempts * delay;
+  }
+
+  return Math.min(wait, maxDelay);
+};

--- a/apps/bot-manager/src/common/utils/default-job-options.ts
+++ b/apps/bot-manager/src/common/utils/default-job-options.ts
@@ -1,0 +1,10 @@
+import { DefaultJobOptions } from 'bullmq';
+
+export const defaultJobOptions: DefaultJobOptions = {
+  attempts: Number.MAX_SAFE_INTEGER,
+  backoff: {
+    type: 'custom',
+  },
+  removeOnComplete: true,
+  removeOnFail: true,
+};

--- a/apps/bot-manager/src/inventories/interfaces/queue.interfaces.ts
+++ b/apps/bot-manager/src/inventories/interfaces/queue.interfaces.ts
@@ -1,0 +1,12 @@
+import { RetryOptions } from '@tf2-automatic/bot-manager-data';
+
+export interface InventoryQueue {
+  raw: {
+    steamid: string;
+    appid: number;
+    contextid: string;
+  };
+  extra: Record<string, unknown>;
+  bot?: string;
+  retry?: RetryOptions;
+}

--- a/apps/bot-manager/src/inventories/interfaces/queue.interfaces.ts
+++ b/apps/bot-manager/src/inventories/interfaces/queue.interfaces.ts
@@ -2,7 +2,7 @@ import { RetryOptions } from '@tf2-automatic/bot-manager-data';
 
 export interface InventoryQueue {
   raw: {
-    steamid: string;
+    steamid64: string;
     appid: number;
     contextid: string;
   };

--- a/apps/bot-manager/src/inventories/inventories.controller.ts
+++ b/apps/bot-manager/src/inventories/inventories.controller.ts
@@ -3,7 +3,6 @@ import {
   Controller,
   Delete,
   Get,
-  NotFoundException,
   Param,
   ParseIntPipe,
   Post,
@@ -77,22 +76,16 @@ export class InventoriesController {
     description: 'The contextid of the inventory',
     example: 2,
   })
-  async getInventory(
+  getInventory(
     @Param('steamid', ParseSteamIDPipe) steamid: SteamID,
     @Param('appid', ParseIntPipe) appid: number,
     @Param('contextid') contextid: string
   ): Promise<InventoryResponse> {
-    const inventory = await this.inventoriesService.getInventoryFromCache(
+    return this.inventoriesService.getInventoryFromCache(
       steamid,
       appid,
       contextid
     );
-
-    if (inventory === null) {
-      throw new NotFoundException('Inventory not found');
-    }
-
-    return inventory;
   }
 
   @Delete(INVENTORY_PATH)

--- a/apps/bot-manager/src/inventories/inventories.controller.ts
+++ b/apps/bot-manager/src/inventories/inventories.controller.ts
@@ -97,8 +97,9 @@ export class InventoriesController {
 
   @Delete(INVENTORY_PATH)
   @ApiOperation({
-    summary: 'Delete cached inventory',
-    description: 'Delete a inventory of a Steam account from the cache.',
+    summary: 'Delete cached inventory and load job if one exists',
+    description:
+      'Delete a inventory of a Steam account from the cache and queue job if one exists.',
   })
   @ApiParamSteamID()
   @ApiParam({

--- a/apps/bot-manager/src/inventories/inventories.controller.ts
+++ b/apps/bot-manager/src/inventories/inventories.controller.ts
@@ -1,10 +1,12 @@
 import {
+  Body,
   Controller,
   Delete,
   Get,
+  NotFoundException,
   Param,
   ParseIntPipe,
-  Query,
+  Post,
   ValidationPipe,
 } from '@nestjs/common';
 import {
@@ -20,7 +22,7 @@ import {
 } from '@tf2-automatic/bot-manager-data';
 import { ParseSteamIDPipe } from '@tf2-automatic/nestjs-steamid-pipe';
 import SteamID from 'steamid';
-import { GetInventoryDto } from '@tf2-automatic/dto';
+import { EnqueueInventoryDto } from '@tf2-automatic/dto';
 import { InventoriesService } from './inventories.service';
 import { ApiParamSteamID, CachedInventoryModel } from '@tf2-automatic/swagger';
 
@@ -28,6 +30,31 @@ import { ApiParamSteamID, CachedInventoryModel } from '@tf2-automatic/swagger';
 @Controller(INVENTORIES_BASE_URL)
 export class InventoriesController {
   constructor(private readonly inventoriesService: InventoriesService) {}
+
+  @Post(INVENTORY_PATH)
+  @ApiOperation({
+    summary: 'Add inventory to queue',
+    description: 'Adds an inventory load job to the queue.',
+  })
+  @ApiParamSteamID()
+  @ApiParam({
+    name: 'appid',
+    description: 'The appid of the game',
+    example: 440,
+  })
+  @ApiParam({
+    name: 'contextid',
+    description: 'The contextid of the inventory',
+    example: 2,
+  })
+  addInventoryToQueue(
+    @Param('steamid', ParseSteamIDPipe) steamid: SteamID,
+    @Param('appid', ParseIntPipe) appid: number,
+    @Param('contextid') contextid: string,
+    @Body(new ValidationPipe()) body: EnqueueInventoryDto
+  ): Promise<void> {
+    return this.inventoriesService.addToQueue(steamid, appid, contextid, body);
+  }
 
   @Get(INVENTORY_PATH)
   @ApiOperation({
@@ -50,23 +77,22 @@ export class InventoriesController {
     description: 'The contextid of the inventory',
     example: 2,
   })
-  getInventory(
+  async getInventory(
     @Param('steamid', ParseSteamIDPipe) steamid: SteamID,
     @Param('appid', ParseIntPipe) appid: number,
-    @Param('contextid') contextid: string,
-    @Query(
-      new ValidationPipe({
-        transform: true,
-      })
-    )
-    query: GetInventoryDto
+    @Param('contextid') contextid: string
   ): Promise<InventoryResponse> {
-    return this.inventoriesService.getInventory(
+    const inventory = await this.inventoriesService.getInventoryFromCache(
       steamid,
       appid,
-      contextid,
-      query
+      contextid
     );
+
+    if (inventory === null) {
+      throw new NotFoundException('Inventory not found');
+    }
+
+    return inventory;
   }
 
   @Delete(INVENTORY_PATH)

--- a/apps/bot-manager/src/inventories/inventories.module.ts
+++ b/apps/bot-manager/src/inventories/inventories.module.ts
@@ -6,6 +6,9 @@ import { HeartbeatsModule } from '../heartbeats/heartbeats.module';
 import { RabbitMQWrapperModule } from '../rabbitmq-wrapper/rabbitmq-wrapper.module';
 import { InventoriesController } from './inventories.controller';
 import { InventoriesService } from './inventories.service';
+import { BullModule } from '@nestjs/bullmq';
+import { InventoriesProcessor } from './inventories.processor';
+import { defaultJobOptions } from '../common/utils/default-job-options';
 
 @Module({
   imports: [
@@ -14,8 +17,12 @@ import { InventoriesService } from './inventories.service';
     HeartbeatsModule,
     RabbitMQWrapperModule,
     EventsModule,
+    BullModule.registerQueue({
+      name: 'inventories',
+      defaultJobOptions,
+    }),
   ],
   controllers: [InventoriesController],
-  providers: [InventoriesService],
+  providers: [InventoriesService, InventoriesProcessor],
 })
 export class InventoriesModule {}

--- a/apps/bot-manager/src/inventories/inventories.processor.ts
+++ b/apps/bot-manager/src/inventories/inventories.processor.ts
@@ -95,7 +95,7 @@ export class InventoriesProcessor extends WorkerHost {
     // Get and save inventory
     const inventory = await this.inventoriesService.getInventoryFromBot(
       bot,
-      new SteamID(job.data.raw.steamid),
+      new SteamID(job.data.raw.steamid64),
       job.data.raw.appid,
       job.data.raw.contextid
     );

--- a/apps/bot-manager/src/inventories/inventories.processor.ts
+++ b/apps/bot-manager/src/inventories/inventories.processor.ts
@@ -1,0 +1,121 @@
+import { OnWorkerEvent, Processor, WorkerHost } from '@nestjs/bullmq';
+import { Logger } from '@nestjs/common';
+import { HttpError } from '@tf2-automatic/bot-data';
+import { AxiosError } from 'axios';
+import { Job, MinimalJob, UnrecoverableError } from 'bullmq';
+import { InventoryQueue } from './interfaces/queue.interfaces';
+import { customBackoffStrategy } from '../common/utils/backoff-strategy';
+import { InventoriesService } from './inventories.service';
+import { HeartbeatsService } from '../heartbeats/heartbeats.service';
+import SteamID from 'steamid';
+import { Bot } from '@tf2-automatic/bot-manager-data';
+
+@Processor('inventories', {
+  settings: {
+    backoffStrategy: (attempts: number, _, __, job: MinimalJob) => {
+      return customBackoffStrategy(attempts, job);
+    },
+  },
+  limiter: {
+    max: 1,
+    duration: 1000,
+  },
+})
+export class InventoriesProcessor extends WorkerHost {
+  private readonly logger = new Logger(InventoriesProcessor.name);
+
+  constructor(
+    private readonly inventoriesService: InventoriesService,
+    private readonly heartbeatsService: HeartbeatsService
+  ) {
+    super();
+  }
+
+  async process(job: Job<InventoryQueue>): Promise<unknown> {
+    this.logger.log(`Processing job ${job.id} attempt #${job.attemptsMade}...`);
+
+    const maxTime = job.data?.retry?.maxTime ?? 120000;
+
+    // Check if job is too old
+    if (job.timestamp < Date.now() - maxTime) {
+      throw new UnrecoverableError('Job is too old');
+    }
+
+    try {
+      // Work on job
+      const result = await this.handleJob(job);
+      return result;
+    } catch (err) {
+      if (err instanceof AxiosError) {
+        const response =
+          err.response satisfies AxiosError<HttpError>['response'];
+
+        if (
+          response !== undefined &&
+          response.status < 500 &&
+          response.status >= 400
+        ) {
+          // Don't retry on 4xx errors
+          throw new UnrecoverableError(response.data.message);
+        }
+      }
+
+      // Check if job will be too old when it can be retried again
+      const delay = customBackoffStrategy(job.attemptsMade, job);
+      if (job.timestamp < Date.now() + delay - maxTime) {
+        throw new UnrecoverableError('Job is too old to be retried');
+      }
+
+      // Unknown error
+      throw err;
+    }
+  }
+
+  private async handleJob(job: Job<InventoryQueue>): Promise<unknown> {
+    let bot: Bot;
+
+    if (job.data.bot) {
+      const botSteamID = new SteamID(job.data.bot);
+
+      bot = await this.heartbeatsService.getBot(botSteamID).catch((err) => {
+        throw new Error(err.message);
+      });
+    } else {
+      // Get list of bots
+      const bots = await this.heartbeatsService.getBots();
+      if (bots.length === 0) {
+        throw new Error('No bots available');
+      }
+
+      bot = bots[Math.floor(Math.random() * bots.length)];
+    }
+
+    this.logger.debug(`Bot ${bot.steamid64} selected`);
+
+    // Get and save inventory
+    const inventory = await this.inventoriesService.getInventoryFromBot(
+      bot,
+      new SteamID(job.data.raw.steamid),
+      job.data.raw.appid,
+      job.data.raw.contextid
+    );
+
+    return inventory.timestamp;
+  }
+
+  @OnWorkerEvent('error')
+  onError(err: Error): void {
+    this.logger.error('Error in worker');
+    console.error(err);
+  }
+
+  @OnWorkerEvent('failed')
+  onFailed(job: Job<InventoryQueue>, err: Error): void {
+    this.logger.warn(`Failed job ${job.id}: ${err.message}`);
+  }
+
+  @OnWorkerEvent('completed')
+  onCompleted(job: Job<InventoryQueue>): void {
+    this.logger.log(`Completed job ${job.id}`);
+  }
+}

--- a/apps/bot-manager/src/inventories/inventories.service.ts
+++ b/apps/bot-manager/src/inventories/inventories.service.ts
@@ -1,7 +1,7 @@
 import { RabbitSubscribe } from '@golevelup/nestjs-rabbitmq';
 import { InjectRedis } from '@liaoliaots/nestjs-redis';
 import { HttpService } from '@nestjs/axios';
-import { Injectable } from '@nestjs/common';
+import { Injectable, NotFoundException } from '@nestjs/common';
 import {
   BOT_EXCHANGE_NAME,
   ExchangeDetailsItem,
@@ -139,13 +139,13 @@ export class InventoriesService {
     steamid: SteamID,
     appid: number,
     contextid: string
-  ): Promise<InventoryResponse | null> {
+  ): Promise<InventoryResponse> {
     const key = this.getInventoryKey(steamid, appid, contextid);
 
     const timestamp = await this.redis.hget(key, 'timestamp');
     if (timestamp === null) {
       // Inventory is not in the cache
-      return null;
+      throw new NotFoundException('Inventory not found');
     }
 
     const object = await this.redis.hgetall(key);

--- a/apps/bot-manager/src/inventories/inventories.service.ts
+++ b/apps/bot-manager/src/inventories/inventories.service.ts
@@ -54,11 +54,9 @@ export class InventoriesService {
     contextid: string,
     dto: EnqueueInventoryDto
   ): Promise<void> {
-    const steamid64 = steamid.getSteamID64();
-
     const data: InventoryQueue = {
       raw: {
-        steamid: steamid64,
+        steamid64: steamid.getSteamID64(),
         appid,
         contextid,
       },

--- a/apps/bot-manager/src/inventories/inventories.service.ts
+++ b/apps/bot-manager/src/inventories/inventories.service.ts
@@ -28,7 +28,6 @@ import { firstValueFrom } from 'rxjs';
 import SteamUser from 'steam-user';
 import SteamID from 'steamid';
 import { EventsService } from '../events/events.service';
-import { HeartbeatsService } from '../heartbeats/heartbeats.service';
 import { EnqueueInventoryDto } from '@tf2-automatic/dto';
 import { InjectQueue } from '@nestjs/bullmq';
 import { Queue } from 'bullmq';
@@ -42,7 +41,6 @@ export class InventoriesService {
     @InjectRedis()
     private readonly redis: Redis,
     private readonly httpService: HttpService,
-    private readonly heartbeatsService: HeartbeatsService,
     private readonly eventsService: EventsService,
     @InjectQueue('inventories')
     private readonly inventoriesQueue: Queue<InventoryQueue>

--- a/apps/bot-manager/src/trades/interfaces/trade-queue.interface.ts
+++ b/apps/bot-manager/src/trades/interfaces/trade-queue.interface.ts
@@ -2,7 +2,7 @@ import { CreateTrade } from '@tf2-automatic/bot-data';
 import {
   ManagerCounterTrade,
   QueueTradeType,
-  RetryTradeOptions,
+  RetryOptions,
 } from '@tf2-automatic/bot-manager-data';
 
 export type TradeQueue =
@@ -37,5 +37,5 @@ interface BaseTradeQueue<
   raw: Raw;
   extra: Extra;
   bot: string;
-  retry?: RetryTradeOptions;
+  retry?: RetryOptions;
 }

--- a/apps/bot-manager/src/trades/processors/trades.processor.ts
+++ b/apps/bot-manager/src/trades/processors/trades.processor.ts
@@ -18,27 +18,7 @@ import {
   TradeQueue,
 } from '../interfaces/trade-queue.interface';
 import { TradesService } from '../trades.service';
-
-type BackoffStrategy = (
-  attemptsMade: number,
-  job: MinimalJob<TradeQueue>
-) => number;
-
-const customBackoffStrategy: BackoffStrategy = (attempts, job) => {
-  const strategy = job.data.retry?.strategy ?? 'exponential';
-  const delay = job.data.retry?.delay ?? 1000;
-  const maxDelay = job.data.retry?.maxDelay ?? 10000;
-
-  let wait = delay;
-
-  if (strategy === 'exponential') {
-    wait = 2 ** (attempts - 1) * delay;
-  } else if (strategy === 'linear') {
-    wait = attempts * delay;
-  }
-
-  return Math.min(wait, maxDelay);
-};
+import { customBackoffStrategy } from '../../common/utils/backoff-strategy';
 
 @Processor('trades', {
   settings: {

--- a/apps/bot-manager/src/trades/trades.module.ts
+++ b/apps/bot-manager/src/trades/trades.module.ts
@@ -7,17 +7,8 @@ import { RabbitMQWrapperModule } from '../rabbitmq-wrapper/rabbitmq-wrapper.modu
 import { ExchangeDetailsProcessor } from './processors/exchange-details.processor';
 import { TradesService } from './trades.service';
 import { TradesController } from './trades.controller';
-import { DefaultJobOptions } from 'bullmq';
 import { TradesProcessor } from './processors/trades.processor';
-
-const defaultJobOptions: DefaultJobOptions = {
-  attempts: Number.MAX_SAFE_INTEGER,
-  backoff: {
-    type: 'custom',
-  },
-  removeOnComplete: true,
-  removeOnFail: true,
-};
+import { defaultJobOptions } from '../common/utils/default-job-options';
 
 @Module({
   imports: [

--- a/libs/bot-manager-data/src/index.ts
+++ b/libs/bot-manager-data/src/index.ts
@@ -5,3 +5,4 @@ export * from './lib/inventories';
 export * from './lib/events';
 export * from './lib/trades';
 export * from './lib/escrow';
+export * from './lib/misc';

--- a/libs/bot-manager-data/src/lib/inventories.ts
+++ b/libs/bot-manager-data/src/lib/inventories.ts
@@ -4,7 +4,6 @@ export const INVENTORIES_BASE_URL = '/inventories';
 export const INVENTORY_PATH = '/:steamid/:appid/:contextid';
 
 export interface InventoryResponse {
-  cached: boolean;
   timestamp: number;
   inventory: Inventory;
 }

--- a/libs/bot-manager-data/src/lib/misc.ts
+++ b/libs/bot-manager-data/src/lib/misc.ts
@@ -1,0 +1,6 @@
+export interface RetryOptions {
+  strategy?: 'exponential' | 'linear' | 'fixed';
+  maxTime?: number;
+  delay?: number;
+  maxDelay?: number;
+}

--- a/libs/bot-manager-data/src/lib/trades.ts
+++ b/libs/bot-manager-data/src/lib/trades.ts
@@ -5,6 +5,7 @@ import {
   TradeOffer,
   TradeOfferExchangeDetails,
 } from '@tf2-automatic/bot-data';
+import { RetryOptions } from './misc';
 
 export const TRADES_BASE_URL = '/trades';
 export const TRADE_JOBS_PATH = `/`;
@@ -12,13 +13,6 @@ export const TRADE_JOB_PATH = `/:id`;
 
 export interface ManagerCounterTrade extends CounterTrade {
   id: string;
-}
-
-export interface RetryTradeOptions {
-  strategy?: 'exponential' | 'linear' | 'fixed';
-  maxTime?: number;
-  delay?: number;
-  maxDelay?: number;
 }
 
 export const QueueTradeTypes = [
@@ -44,7 +38,7 @@ export interface QueueTrade<
   data: Data;
   bot: string;
   priority?: number;
-  retry?: RetryTradeOptions;
+  retry?: RetryOptions;
 }
 
 export interface QueueTradeResponse {

--- a/libs/dto/src/index.ts
+++ b/libs/dto/src/index.ts
@@ -5,3 +5,4 @@ export * from './lib/friends';
 export * from './lib/inventories';
 export * from './lib/heartbeats';
 export * from './lib/escrow';
+export * from './lib/misc';

--- a/libs/dto/src/lib/inventories.ts
+++ b/libs/dto/src/lib/inventories.ts
@@ -1,18 +1,37 @@
 import { ApiProperty } from '@nestjs/swagger';
 import { IsSteamID } from '@tf2-automatic/is-steamid-validator';
-import { Transform } from 'class-transformer';
-import { IsOptional } from 'class-validator';
-import SteamID from 'steamid';
+import { Type } from 'class-transformer';
+import { IsInt, IsOptional, Max, Min, ValidateNested } from 'class-validator';
+import { QueueRetryDto } from './misc';
 
-export class GetInventoryDto {
+export class EnqueueInventoryDto {
   @ApiProperty({
-    description: 'SteamID64 of bot to fetch the inventory from',
+    description: 'The steamid64 of the bot to fetch the inventory with',
     example: '76561198120070906',
-    type: String,
-    required: false,
   })
   @IsSteamID()
   @IsOptional()
-  @Transform((params) => new SteamID(params.value))
-  bot?: SteamID;
+  bot?: string;
+
+  @ApiProperty({
+    description:
+      'The priority of the job. The closter to 1 the higher the priority.',
+    example: 1,
+    required: false,
+  })
+  @IsOptional()
+  @IsInt()
+  @Min(1)
+  @Max(Number.MAX_SAFE_INTEGER)
+  priority?: number;
+
+  @ApiProperty({
+    description: 'The options for the job',
+    type: QueueRetryDto,
+    required: false,
+  })
+  @IsOptional()
+  @ValidateNested()
+  @Type(() => QueueRetryDto)
+  retry: QueueRetryDto;
 }

--- a/libs/dto/src/lib/misc.ts
+++ b/libs/dto/src/lib/misc.ts
@@ -1,0 +1,45 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { RetryOptions } from '@tf2-automatic/bot-manager-data';
+import { IsEnum, IsInt, IsOptional, Min } from 'class-validator';
+
+export class QueueRetryDto implements RetryOptions {
+  @ApiProperty({
+    description: 'The retry strategy to use',
+    required: false,
+    example: 'exponential',
+  })
+  @IsOptional()
+  @IsEnum(['exponential', 'linear', 'fixed'])
+  strategy?: 'exponential' | 'linear' | 'fixed';
+
+  @ApiProperty({
+    description:
+      'Maximum amount of time in milliseconds the job will be retried for until it fails',
+    example: 60000,
+    required: false,
+  })
+  @IsOptional()
+  @IsInt()
+  @Min(10000)
+  maxTime?: number;
+
+  @ApiProperty({
+    description: 'Delay between retries in milliseconds',
+    example: 1000,
+    required: false,
+  })
+  @IsOptional()
+  @IsInt()
+  @Min(1000)
+  delay?: number;
+
+  @ApiProperty({
+    description: 'Maximum delay between retries in milliseconds',
+    example: 10000,
+    required: false,
+  })
+  @IsOptional()
+  @IsInt()
+  @Min(10000)
+  maxDelay?: number;
+}

--- a/libs/dto/src/lib/trades.ts
+++ b/libs/dto/src/lib/trades.ts
@@ -12,7 +12,6 @@ import {
   QueueTrade,
   QueueTradeType,
   QueueTradeTypes,
-  RetryTradeOptions,
 } from '@tf2-automatic/bot-manager-data';
 import { IsSteamID } from '@tf2-automatic/is-steamid-validator';
 import { Type } from 'class-transformer';
@@ -32,6 +31,7 @@ import {
   ValidatorConstraint,
   ValidatorConstraintInterface,
 } from 'class-validator';
+import { QueueRetryDto } from './misc';
 
 export class AssetDto implements Asset {
   @ApiProperty({
@@ -142,48 +142,6 @@ export class GetTradesDto implements GetTrades {
   filter: OfferFilter;
 }
 
-export class QueueTradeRetryDto implements RetryTradeOptions {
-  @ApiProperty({
-    description: 'The retry strategy to use',
-    required: false,
-    example: 'exponential',
-  })
-  @IsOptional()
-  @IsEnum(['exponential', 'linear', 'fixed'])
-  strategy?: 'exponential' | 'linear' | 'fixed';
-
-  @ApiProperty({
-    description:
-      'Maximum amount of time in milliseconds the job will be retried for until it fails',
-    example: 60000,
-    required: false,
-  })
-  @IsOptional()
-  @IsInt()
-  @Min(10000)
-  maxTime?: number;
-
-  @ApiProperty({
-    description: 'Delay between retries in milliseconds',
-    example: 1000,
-    required: false,
-  })
-  @IsOptional()
-  @IsInt()
-  @Min(1000)
-  delay?: number;
-
-  @ApiProperty({
-    description: 'Maximum delay between retries in milliseconds',
-    example: 10000,
-    required: false,
-  })
-  @IsOptional()
-  @IsInt()
-  @Min(10000)
-  maxDelay?: number;
-}
-
 @ValidatorConstraint()
 export class TradeQueueDataValidator implements ValidatorConstraintInterface {
   validate(object: unknown, args: ValidationArguments) {
@@ -281,11 +239,11 @@ export class TradeQueueJobDto implements QueueTrade {
 
   @ApiProperty({
     description: 'The options for the job',
-    type: QueueTradeRetryDto,
+    type: QueueRetryDto,
     required: false,
   })
   @IsOptional()
   @ValidateNested()
-  @Type(() => QueueTradeRetryDto)
-  retry: QueueTradeRetryDto;
+  @Type(() => QueueRetryDto)
+  retry: QueueRetryDto;
 }


### PR DESCRIPTION
Instead of getting the inventory from the bot if it is not in the cache, you instead add the
inventory to the queue and it will eventually be loaded depending on the configured retry options.

BREAKING CHANGE: In order to load an inventory, you need to add it to the queue and wait for it to
be fetched.