### PR TITLE
feat(bot): confirmation needed event

### DIFF
--- a/apps/bot/src/events/events.service.ts
+++ b/apps/bot/src/events/events.service.ts
@@ -18,10 +18,7 @@ export class EventsService implements OnModuleDestroy {
     return (this.amqpConnection.channel as ConfirmChannel).waitForConfirms();
   }
 
-  async publish(
-    event: string,
-    data: { [key: string]: unknown } = {}
-  ): Promise<void> {
+  async publish(event: string, data: object = {}): Promise<void> {
     const steamid64 = this.metadataService.getSteamID()?.getSteamID64() ?? null;
 
     await this.amqpConnection.publish(BOT_EXCHANGE_NAME, event, {

--- a/apps/bot/src/trades/trades.service.ts
+++ b/apps/bot/src/trades/trades.service.ts
@@ -14,6 +14,8 @@ import {
   TRADE_CHANGED_EVENT,
   TRADE_RECEIVED_EVENT,
   TRADE_SENT_EVENT,
+  TRADE_CONFIRMATION_NEEDED_EVENT,
+  TradeConfirmationNeededEvent,
 } from '@tf2-automatic/bot-data';
 import { SteamException } from '../common/exceptions/eresult.exception';
 import { Config, SteamAccountConfig } from '../common/config/configuration';
@@ -94,6 +96,44 @@ export class TradesService {
     this.manager.once('pollSuccess', () => {
       this.ensurePollData();
     });
+
+    // Capture offers from getOffers function to detect relevant changes
+    const origGetOffers = this.manager.getOffers.bind(this.manager);
+    this.manager.getOffers = (...args) => {
+      const callback = args.pop();
+      origGetOffers(...args, (err, sent, received) => {
+        if (err) {
+          return callback(err);
+        }
+
+        callback(err, sent, received);
+
+        try {
+          this.handleOffers(sent, received);
+        } catch (err) {
+          // Catch the error because we don't want trade offer manager to think an error occurred
+          this.logger.warn('Error while handling offers: ' + err.message);
+        }
+      });
+    };
+  }
+
+  private handleOffers(
+    sent: SteamTradeOfferManager.TradeOffer[],
+    received: SteamTradeOfferManager.TradeOffer[]
+  ) {
+    // Check if confirmation method is set and it has not been published
+    for (const offer of sent) {
+      this.ensureConfirmationPublished(offer).catch(() => {
+        // Ignore error
+      });
+    }
+
+    for (const offer of received) {
+      this.ensureConfirmationPublished(offer).catch(() => {
+        // Ignore error
+      });
+    }
   }
 
   private ensurePollData(): void {
@@ -196,6 +236,32 @@ export class TradesService {
     }
 
     return this.publishOffer(offer, publishedState);
+  }
+
+  private ensureConfirmationPublished(
+    offer: SteamTradeOfferManager.TradeOffer
+  ): Promise<void> {
+    if (
+      offer.confirmationMethod ==
+        SteamTradeOfferManager.EConfirmationMethod.None ||
+      offer.data('conf') === true
+    ) {
+      return Promise.resolve();
+    }
+
+    // Publish confirmation
+    return this.eventsService
+      .publish(
+        TRADE_CONFIRMATION_NEEDED_EVENT,
+        this.mapOffer(offer) satisfies TradeConfirmationNeededEvent['data']
+      )
+      .then(() => {
+        // Update offer data to prevent publishing confirmation multiple times
+        offer.data('conf', true);
+      })
+      .catch(() => {
+        // Ignore error
+      });
   }
 
   private handleOfferChanged(

--- a/apps/bot/src/trades/trades.service.ts
+++ b/apps/bot/src/trades/trades.service.ts
@@ -49,7 +49,7 @@ export class TradesService {
   private readonly community = this.botService.getCommunity();
 
   private readonly ensureOfferPublishedQueue: queueAsPromised<EnsureOfferPublishedTask> =
-    fastq.promise(this.ensureOfferPublished.bind(this), 1);
+    fastq.promise(this.ensureOfferPublishedProcessor.bind(this), 1);
 
   private ensurePollDataTimeout: NodeJS.Timeout | null = null;
   private ensureOfferPublishedLimiter = new Bottleneck({

--- a/libs/bot-data/src/lib/trades.ts
+++ b/libs/bot-data/src/lib/trades.ts
@@ -95,11 +95,13 @@ export const TRADE_COUNTER_PATH = `${TRADE_PATH}/counter`;
 export type TradeSentEventType = 'trades.sent';
 export type TradeReceivedEventType = 'trades.received';
 export type TradeChangedEventType = 'trades.changed';
+export type TradeConfirmationNeededEventType = 'trades.confirmation_needed';
 
 export const TRADE_EVENT_PREFIX = 'trades';
 export const TRADE_SENT_EVENT: TradeSentEventType = `${TRADE_EVENT_PREFIX}.sent`;
 export const TRADE_RECEIVED_EVENT: TradeReceivedEventType = `${TRADE_EVENT_PREFIX}.received`;
 export const TRADE_CHANGED_EVENT: TradeChangedEventType = `${TRADE_EVENT_PREFIX}.changed`;
+export const TRADE_CONFIRMATION_NEEDED_EVENT: TradeConfirmationNeededEventType = `${TRADE_EVENT_PREFIX}.confirmation_needed`;
 
 export type TradeSentEvent = BaseEvent<TradeSentEventType, TradeOffer>;
 
@@ -111,4 +113,9 @@ export type TradeChangedEvent = BaseEvent<
     offer: TradeOffer;
     oldState: ETradeOfferState | null;
   }
+>;
+
+export type TradeConfirmationNeededEvent = BaseEvent<
+  TradeConfirmationNeededEventType,
+  TradeOffer
 >;


### PR DESCRIPTION
An event will now be published when an offer is accepted or sent and needs to be confirmed

Fixes #250