### PR TITLE
feat(bot-manager): handle trade rollbacks

### DIFF
--- a/apps/bot-manager/src/inventories/inventories.service.ts
+++ b/apps/bot-manager/src/inventories/inventories.service.ts
@@ -338,20 +338,9 @@ export class InventoriesService {
     // Create an object of inventory keys which each contains an array of items to delete
     const lostItems: Record<string, string[]> = {};
 
-    const addLostItems = (steamid: SteamID, items: Item[]) => {
-      items.reduce((acc, cur) => {
-        const items = (acc[
-          this.getInventoryKey(steamid, cur.appid, cur.contextid)
-        ] = acc[cur.appid] ?? []);
-
-        items.push('item:' + cur.assetid);
-        return acc;
-      }, lostItems);
-    };
-
     // Add items to the object
-    addLostItems(ourSteamID, event.data.offer.itemsToGive);
-    addLostItems(theirSteamID, event.data.offer.itemsToReceive);
+    this.addLostItems(lostItems, ourSteamID, event.data.offer.itemsToGive);
+    this.addLostItems(lostItems, theirSteamID, event.data.offer.itemsToReceive);
 
     const transaction = this.redis.multi();
 

--- a/apps/bot-manager/src/inventories/inventories.service.ts
+++ b/apps/bot-manager/src/inventories/inventories.service.ts
@@ -331,8 +331,7 @@ export class InventoriesService {
       return;
     }
 
-    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-    const ourSteamID = new SteamID(event.metadata.steamid64!);
+    const ourSteamID = new SteamID(event.metadata.steamid64 as string);
     const theirSteamID = new SteamID(event.data.offer.partner);
 
     // Create an object of inventory keys which each contains an array of items to delete

--- a/apps/bot-manager/src/inventories/inventories.service.ts
+++ b/apps/bot-manager/src/inventories/inventories.service.ts
@@ -327,7 +327,10 @@ export class InventoriesService {
   }
 
   private async handleOfferChanged(event: TradeChangedEvent): Promise<void> {
-    if (event.data.offer.state !== SteamUser.ETradeOfferState.Accepted) {
+    if (
+      event.data.offer.state !== SteamUser.ETradeOfferState.Accepted &&
+      event.data.offer.state !== SteamUser.ETradeOfferState.InEscrow
+    ) {
       return;
     }
 

--- a/apps/bot-manager/src/inventories/inventories.service.ts
+++ b/apps/bot-manager/src/inventories/inventories.service.ts
@@ -204,38 +204,7 @@ export class InventoriesService {
     steamid: SteamID,
     items: ExchangeDetailsItem[]
   ) {
-    const mapItem = (item: ExchangeDetailsItem): Item => {
-      const newItem = { ...item };
-
-      // Overwrite assetid and contextid using new values first
-
-      if (item.new_assetid !== undefined) {
-        newItem.assetid = item.new_assetid;
-        delete newItem.new_assetid;
-      }
-
-      if (item.new_contextid !== undefined) {
-        newItem.contextid = item.new_contextid;
-        delete newItem.new_contextid;
-      }
-
-      // Overwrite assetid and contextid using rollback values at the end
-      // because the rollback values are more accurate
-
-      if (item.rollback_new_assetid !== undefined) {
-        newItem.assetid = item.rollback_new_assetid;
-        delete newItem.rollback_new_assetid;
-      }
-
-      if (item.rollback_new_contextid !== undefined) {
-        newItem.contextid = item.rollback_new_contextid;
-        delete newItem.rollback_new_contextid;
-      }
-
-      return newItem;
-    };
-
-    items.map(mapItem).reduce((acc, cur) => {
+    items.reduce((acc, cur) => {
       const items = (acc[
         this.getInventoryKey(steamid, cur.appid, cur.contextid)
       ] = acc[cur.appid] ?? []);

--- a/apps/bot-manager/src/trades/trades.service.ts
+++ b/apps/bot-manager/src/trades/trades.service.ts
@@ -33,7 +33,6 @@ import {
 import { CreateTradeDto, GetTradesDto } from '@tf2-automatic/dto';
 import { Job as BullJob, Queue } from 'bullmq';
 import { firstValueFrom } from 'rxjs';
-import SteamUser from 'steam-user';
 import SteamID from 'steamid';
 import { HeartbeatsService } from '../heartbeats/heartbeats.service';
 import { ExchangeDetailsQueueData } from './interfaces/exchange-details-queue.interface';
@@ -234,12 +233,8 @@ export class TradesService {
     errorHandler: requeueErrorHandler,
   })
   public async handleTradeChanged(event: TradeChangedEvent) {
-    if (
-      (event.data.offer.state === SteamUser.ETradeOfferState.Canceled &&
-        event.data.offer.tradeID !== null) ||
-      event.data.offer.state !== SteamUser.ETradeOfferState.Accepted
-    ) {
-      // Trade is not canceled and was previously accepted, or it is not accepted
+    if (event.data.offer.tradeID === null) {
+      // Trade has not been accepted
       return;
     }
 

--- a/apps/bot-manager/src/trades/trades.service.ts
+++ b/apps/bot-manager/src/trades/trades.service.ts
@@ -234,7 +234,12 @@ export class TradesService {
     errorHandler: requeueErrorHandler,
   })
   public async handleTradeChanged(event: TradeChangedEvent) {
-    if (event.data.offer.state !== SteamUser.ETradeOfferState.Accepted) {
+    if (
+      (event.data.offer.state === SteamUser.ETradeOfferState.Canceled &&
+        event.data.offer.tradeID !== null) ||
+      event.data.offer.state !== SteamUser.ETradeOfferState.Accepted
+    ) {
+      // Trade is not canceled and was previously accepted, or it is not accepted
       return;
     }
 


### PR DESCRIPTION
If an offer is canceled but has a tradeID, then the offer was previously accepted and the items are moved back.

BREAKING CHANGE: Renamed RabbitMQ queue "bot-manager.add-inventory-items" to "bot-manager.update-inventory-items"