### PR TITLE
fix incorrect and inconsistent offer event types

### DIFF
--- a/apps/bot/src/trades/trades.service.ts
+++ b/apps/bot/src/trades/trades.service.ts
@@ -15,7 +15,6 @@ import {
   TRADE_RECEIVED_EVENT,
   TRADE_SENT_EVENT,
   TRADE_CONFIRMATION_NEEDED_EVENT,
-  TradeConfirmationNeededEvent,
 } from '@tf2-automatic/bot-data';
 import { SteamException } from '../common/exceptions/eresult.exception';
 import { Config, SteamAccountConfig } from '../common/config/configuration';
@@ -248,10 +247,9 @@ export class TradesService {
 
     // Publish confirmation
     return this.eventsService
-      .publish(
-        TRADE_CONFIRMATION_NEEDED_EVENT,
-        this.mapOffer(offer) satisfies TradeConfirmationNeededEvent['data'],
-      )
+      .publish(TRADE_CONFIRMATION_NEEDED_EVENT, {
+        offer: this.mapOffer(offer),
+      })
       .then(() => {
         // Update offer data to prevent publishing confirmation multiple times
         offer.data('conf', offer.data('accept'));

--- a/libs/bot-data/src/lib/trades.ts
+++ b/libs/bot-data/src/lib/trades.ts
@@ -48,6 +48,10 @@ export interface TradeOffer {
   escrowEndsAt: number | null;
 }
 
+interface BaseOfferEvent {
+  offer: TradeOffer;
+}
+
 export interface GetTradesResponse {
   sent: TradeOffer[];
   received: TradeOffer[];
@@ -103,19 +107,19 @@ export const TRADE_RECEIVED_EVENT: TradeReceivedEventType = `${TRADE_EVENT_PREFI
 export const TRADE_CHANGED_EVENT: TradeChangedEventType = `${TRADE_EVENT_PREFIX}.changed`;
 export const TRADE_CONFIRMATION_NEEDED_EVENT: TradeConfirmationNeededEventType = `${TRADE_EVENT_PREFIX}.confirmation_needed`;
 
-export type TradeSentEvent = BaseEvent<TradeSentEventType, TradeOffer>;
+export type TradeSentEvent = BaseEvent<TradeSentEventType, BaseOfferEvent>;
 
-export type TradeReceivedEvent = BaseEvent<TradeReceivedEventType, TradeOffer>;
+export type TradeReceivedEvent = BaseEvent<
+  TradeReceivedEventType,
+  BaseOfferEvent
+>;
 
 export type TradeChangedEvent = BaseEvent<
   TradeChangedEventType,
-  {
-    offer: TradeOffer;
-    oldState: ETradeOfferState | null;
-  }
+  BaseOfferEvent & { oldState: ETradeOfferState | null }
 >;
 
 export type TradeConfirmationNeededEvent = BaseEvent<
   TradeConfirmationNeededEventType,
-  TradeOffer
+  BaseOfferEvent
 >;


### PR DESCRIPTION
`TRADE_CONFIRMATION_NEEDED_EVENT` was inconsistent with the rest of the trade offer events. The types provided for the rest were incorrect.