### PR TITLE
feat(bot-manager): add partial item to inventory on tf2 event

### DIFF
--- a/libs/bot-manager-data/src/lib/inventories.ts
+++ b/libs/bot-manager-data/src/lib/inventories.ts
@@ -1,12 +1,20 @@
-import { BaseEvent, HttpError, Inventory, Item } from '@tf2-automatic/bot-data';
+import { BaseEvent, HttpError, Item } from '@tf2-automatic/bot-data';
 import { RetryOptions } from './misc';
 
 export const INVENTORIES_BASE_URL = '/inventories';
 export const INVENTORY_PATH = '/:steamid/:appid/:contextid';
 
+export type InventoryItem =
+  | Item
+  | {
+      appid: number;
+      contextid: string;
+      assetid: string;
+    };
+
 export interface InventoryResponse {
   timestamp: number;
-  inventory: Inventory;
+  inventory: InventoryItem[];
 }
 
 export interface EnqueueInventory {
@@ -74,8 +82,8 @@ export type InventoryChangedEvent = BaseEvent<
     steamid64: string;
     appid: number;
     contextid: string;
-    gained: Item[];
-    lost: Item[];
+    gained: InventoryItem[];
+    lost: InventoryItem[];
     reason: InventoryChangedEventReason;
   }
 >;


### PR DESCRIPTION
Keep track of items gained using TF2 events

BREAKING CHANGE: Inventory items can be partial and only consist of an appid, contextid and assetid

Fix #284