### PR TITLE
feat(bot): play custom game

### DIFF
--- a/apps/bot/src/bot/bot.service.ts
+++ b/apps/bot/src/bot/bot.service.ts
@@ -237,6 +237,10 @@ export class BotService implements OnModuleDestroy {
   }
 
   setCustomGame(gameName: string | null) {
+    if (gameName === this.customGamePlayed) {
+      return;
+    }
+
     this.customGamePlayed = gameName;
 
     // eslint-disable-next-line @typescript-eslint/ban-ts-comment

--- a/apps/bot/src/bot/bot.service.ts
+++ b/apps/bot/src/bot/bot.service.ts
@@ -243,6 +243,10 @@ export class BotService implements OnModuleDestroy {
     // @ts-expect-error _playingAppIds is private
     const gamesPlayed: number[] = this.client._playingAppIds;
 
+    if (this.customGamePlayed !== null) {
+      this.client.gamesPlayed([]);
+    }
+
     this.setGamePlayed(gamesPlayed.length > 0 ? gamesPlayed[0] : null);
   }
 

--- a/apps/bot/src/bot/bot.service.ts
+++ b/apps/bot/src/bot/bot.service.ts
@@ -63,6 +63,7 @@ export class BotService implements OnModuleDestroy {
   });
   private manager: SteamTradeOfferManager;
   private session: LoginSession | null = null;
+  private customGamePlayed: string | null = null;
 
   private _startPromise: Promise<void> | null = null;
   private _reconnectPromise: Promise<void> | null = null;
@@ -142,6 +143,8 @@ export class BotService implements OnModuleDestroy {
     this.client.on('loggedOn', () => {
       this.logger.log('Logged in to Steam!');
 
+      this.setGamePlayed(440);
+
       if (this.running) {
         this.client.setPersona(SteamUser.EPersonaState.Online);
       }
@@ -217,6 +220,32 @@ export class BotService implements OnModuleDestroy {
     return this.community;
   }
 
+  setGamePlayed(appid: number | null) {
+    const gamesPlayed: (string | number)[] = [];
+
+    // When we leave TF2 we also want to leave the custom game.
+    // This is because Steam shows whichever game was played last
+    // and we want to show the custom game instead of TF2.
+    if (appid) {
+      if (this.customGamePlayed) {
+        gamesPlayed.push(this.customGamePlayed);
+      }
+      gamesPlayed.push(appid);
+    }
+
+    this.client.gamesPlayed(gamesPlayed);
+  }
+
+  setCustomGame(gameName: string | null) {
+    this.customGamePlayed = gameName;
+
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    // @ts-expect-error _playingAppIds is private
+    const gamesPlayed: number[] = this.client._playingAppIds;
+
+    this.setGamePlayed(gamesPlayed.length > 0 ? gamesPlayed[0] : null);
+  }
+
   private handleReadEvent(
     filename: string,
     callback: (err: Error | null, contents?: Buffer | null) => void,
@@ -256,6 +285,26 @@ export class BotService implements OnModuleDestroy {
     return this._startPromise;
   }
 
+  private async getCustomGame(): Promise<string | null> {
+    if (this.customGamePlayed) {
+      return this.customGamePlayed;
+    }
+
+    const customGamePath = `customgame.${
+      this.configService.getOrThrow<SteamAccountConfig>('steam').username
+    }.txt`;
+
+    const customGame = await this.storageService
+      .read(customGamePath)
+      .catch(null);
+
+    if (customGame) {
+      this.customGamePlayed = customGame;
+    }
+
+    return this.customGamePlayed;
+  }
+
   private async _start(): Promise<void> {
     this.community.on('sessionExpired', () => {
       this.logger.debug('Web session expired');
@@ -276,6 +325,8 @@ export class BotService implements OnModuleDestroy {
     this.manager.on('debug', (message: string) => {
       this.logger.debug(message);
     });
+
+    await this.getCustomGame();
 
     await this.reconnect();
 

--- a/apps/bot/src/profile/profile.controller.ts
+++ b/apps/bot/src/profile/profile.controller.ts
@@ -18,6 +18,7 @@ import {
 import {
   PROFILE_AVATAR_PATH,
   PROFILE_BASE_URL,
+  PROFILE_CUSTOM_GAME_PATH,
   PROFILE_NAME_PATH,
   PROFILE_PATH,
   PROFILE_SETTINGS_PATH,
@@ -25,6 +26,7 @@ import {
   TradeOfferUrlResponse,
 } from '@tf2-automatic/bot-data';
 import {
+  UpdateCustomGameDto,
   UpdateProfileAvatarDto,
   UpdateProfileDto,
   UpdateProfileSettingsDto,
@@ -122,5 +124,26 @@ export class ProfileController {
     return this.profileService.changeTradeOfferUrl().then((url) => {
       return { url };
     });
+  }
+
+  @Put(PROFILE_CUSTOM_GAME_PATH)
+  @ApiOperation({
+    summary: 'Set a custom game',
+    description: 'Set a custom game for the bot, it will always be in TF2',
+  })
+  @ApiBody({
+    type: UpdateCustomGameDto,
+  })
+  setCustomGame(@Body(new ValidationPipe()) dto: UpdateCustomGameDto) {
+    return this.profileService.setCustomGame(dto);
+  }
+
+  @Delete(PROFILE_CUSTOM_GAME_PATH)
+  @ApiOperation({
+    summary: 'Clear the custom game',
+    description: 'Clear the bots custom game and return to TF2 only',
+  })
+  clearCustomGame() {
+    return this.profileService.clearCustomGame();
   }
 }

--- a/apps/bot/src/profile/profile.module.ts
+++ b/apps/bot/src/profile/profile.module.ts
@@ -2,9 +2,10 @@ import { Module } from '@nestjs/common';
 import { ProfileService } from './profile.service';
 import { ProfileController } from './profile.controller';
 import { BotModule } from '../bot/bot.module';
+import { StorageModule } from '../storage/storage.module';
 
 @Module({
-  imports: [BotModule],
+  imports: [StorageModule, BotModule],
   providers: [ProfileService],
   controllers: [ProfileController],
 })

--- a/apps/bot/src/profile/profile.service.ts
+++ b/apps/bot/src/profile/profile.service.ts
@@ -111,7 +111,7 @@ export class ProfileService {
       return Promise.reject();
     }
 
-    return this.client.gamesPlayed([dto.name, 440]);
+    this.botService.setCustomGame(dto.name === '' ? null : dto.name);
   }
 
   async clearCustomGame() {
@@ -130,6 +130,6 @@ export class ProfileService {
       return Promise.reject();
     }
 
-    return this.client.gamesPlayed([440]);
+    this.botService.setCustomGame(null);
   }
 }

--- a/apps/bot/src/tf2/tf2.module.ts
+++ b/apps/bot/src/tf2/tf2.module.ts
@@ -3,9 +3,10 @@ import { BotModule } from '../bot/bot.module';
 import { EventsModule } from '../events/events.module';
 import { TF2Controller } from './tf2.controller';
 import { TF2Service } from './tf2.service';
+import { StorageModule } from '../storage/storage.module';
 
 @Module({
-  imports: [BotModule, EventsModule],
+  imports: [StorageModule, BotModule, EventsModule],
   controllers: [TF2Controller],
   providers: [TF2Service],
 })

--- a/apps/bot/src/tf2/tf2.service.ts
+++ b/apps/bot/src/tf2/tf2.service.ts
@@ -21,6 +21,9 @@ import fastq from 'fastq';
 import type { queueAsPromised } from 'fastq';
 import { EventsService } from '../events/events.service';
 import { CraftDto, SortBackpackDto } from '@tf2-automatic/dto';
+import { StorageService } from '../storage/storage.service';
+import { ConfigService } from '@nestjs/config';
+import { Config, SteamAccountConfig } from '../common/config/configuration';
 
 // Stop node-tf2 from fetching the item schema
 delete TeamFortress2.prototype._handlers[TF2Language.UpdateItemSchema];
@@ -84,10 +87,12 @@ export class TF2Service implements OnApplicationShutdown {
   constructor(
     private readonly botService: BotService,
     private readonly eventsService: EventsService,
+    private readonly storageService: StorageService,
+    private readonly configService: ConfigService<Config>,
   ) {
     this.client.on('loggedOn', () => {
       // Bot is logged in, connect to TF2 GC
-      this.client.gamesPlayed([440]);
+      this.playGames();
     });
 
     this.tf2.on('connectedToGC', () => {
@@ -104,7 +109,7 @@ export class TF2Service implements OnApplicationShutdown {
 
         // Add timeout to give Steam some time before we open the app again
         setTimeout(() => {
-          this.client.gamesPlayed([440]);
+          this.playGames();
         }, 1000);
       }
     });
@@ -138,6 +143,26 @@ export class TF2Service implements OnApplicationShutdown {
           // Ignore error
         });
     });
+  }
+
+  private async playGames() {
+    // Check the custom game file and play that if it exists, otherwise play only TF2
+    const customGamePath = `customgame.${
+      this.configService.getOrThrow<SteamAccountConfig>('steam').username
+    }.txt`;
+
+    const customGame = await this.storageService
+      .read(customGamePath)
+      .catch(() => {
+        return null;
+      });
+
+    // Not explicitly checking for null here because it can be an empty string
+    if (customGame) {
+      return this.client.gamesPlayed([customGame, 440]);
+    }
+
+    return this.client.gamesPlayed([440]);
   }
 
   private refreshInventory(): void {
@@ -316,7 +341,7 @@ export class TF2Service implements OnApplicationShutdown {
   async connectToGC(): Promise<void> {
     if (!this.isPlayingTF2()) {
       // Not playing TF2
-      this.client.gamesPlayed([440]);
+      await this.playGames();
     }
 
     if (this.tf2.haveGCSession) {

--- a/libs/bot-data/src/lib/profile.ts
+++ b/libs/bot-data/src/lib/profile.ts
@@ -1,5 +1,9 @@
 import type SteamCommunity from 'steamcommunity';
 
+export interface UpdateCustomGame {
+  name: string;
+}
+
 export interface UpdateProfileAvatar {
   url: string;
 }
@@ -41,3 +45,4 @@ export const PROFILE_PATH = '/';
 export const PROFILE_SETTINGS_PATH = '/settings';
 export const PROFILE_NAME_PATH = '/name';
 export const PROFILE_TRADEOFFERURL_PATH = '/tradeofferurl';
+export const PROFILE_CUSTOM_GAME_PATH = '/game';

--- a/libs/dto/src/lib/profile.ts
+++ b/libs/dto/src/lib/profile.ts
@@ -1,5 +1,6 @@
 import { ApiProperty } from '@nestjs/swagger';
 import {
+  UpdateCustomGame,
   UpdateProfile,
   UpdateProfileAvatar,
   UpdateProfileSettings,
@@ -25,6 +26,15 @@ export class UpdateProfileAvatarDto implements UpdateProfileAvatar {
     protocols: ['http', 'https'],
   })
   url: string;
+}
+
+export class UpdateCustomGameDto implements UpdateCustomGame {
+  @ApiProperty({
+    description: 'The custom game name',
+    example: 'A super cool game!',
+  })
+  @IsString()
+  name: string;
 }
 
 export class UpdateProfileSettingsDto implements UpdateProfileSettings {


### PR DESCRIPTION
Set the bots custom game (alongside TF2) through API

Includes `PUT /profile/game` with body:
```json
{
    "name": "Super cool game!"
}
```
And `DELETE /profile/game` to go back to playing TF2 only
Setting the name to an empty string will have the same effect as calling the DELETE API

Using PUT to be consistent with the other profile APIs