### PR TITLE
refactor(bptf-manager): refactor and test desired listings

### DIFF
--- a/apps/bptf-manager/src/listings/classes/desired-listing.class.ts
+++ b/apps/bptf-manager/src/listings/classes/desired-listing.class.ts
@@ -39,7 +39,7 @@ export class DesiredListing {
     return this.id;
   }
 
-  setID(id: string): void {
+  setID(id: string | undefined): void {
     this.id = id;
   }
 
@@ -59,7 +59,7 @@ export class DesiredListing {
     return this.error;
   }
 
-  setError(error: ListingError): void {
+  setError(error: ListingError | undefined): void {
     this.error = error;
   }
 

--- a/apps/bptf-manager/src/listings/desired-listings.service.ts
+++ b/apps/bptf-manager/src/listings/desired-listings.service.ts
@@ -153,8 +153,24 @@ export class DesiredListingsService {
       );
   }
 
+  async getAllDesiredInternalNew(
+    steamid: SteamID,
+  ): Promise<DesiredListingClass[]> {
+    const values = await this.redis.hvals(this.getDesiredKey(steamid));
+
+    const desired = values.map((raw) =>
+      ListingFactory.CreateDesiredListing(
+        JSON.parse(raw) as DesiredListingInternal,
+      ),
+    );
+
+    return desired;
+  }
+
   async getAllDesired(steamid: SteamID): Promise<DesiredListing[]> {
-    return this.getAllDesiredInternal(steamid).then(this.mapDesired);
+    const desired = await this.getAllDesiredInternalNew(steamid);
+
+    return this.mapDesired(desired.map((d) => d.toJSON()));
   }
 
   async getDesiredByHashesNew(

--- a/apps/bptf-manager/src/listings/desired-listings.service.ts
+++ b/apps/bptf-manager/src/listings/desired-listings.service.ts
@@ -63,10 +63,10 @@ export class DesiredListingsService {
         );
 
         const transaction = this.redis.multi();
-        this.chainableSaveDesired(
+        DesiredListingsService.chainableSaveDesired(
           transaction,
           steamid,
-          desired.map((d) => d.toJSON()),
+          desired,
         );
         await transaction.exec();
 

--- a/apps/bptf-manager/src/listings/listeners/desired-listings.listener.spec.ts
+++ b/apps/bptf-manager/src/listings/listeners/desired-listings.listener.spec.ts
@@ -1,0 +1,203 @@
+import { EventEmitter2, EventEmitterModule } from '@nestjs/event-emitter';
+import { mock } from '@tf2-automatic/testing';
+import { DesiredListingsListener } from './desired-listings.listener';
+import { getRedisToken } from '@songkeys/nestjs-redis';
+import { Test, TestingModule } from '@nestjs/testing';
+import { DesiredListingsService } from '../desired-listings.service';
+import { ListingError } from '../interfaces/desired-listing.interface';
+import SteamID from 'steamid';
+import { DesiredListing as DesiredListingClass } from '../classes/desired-listing.class';
+import { DesiredListing } from '../interfaces/desired-listing.interface';
+import hashListing from '../utils/desired-listing-hash';
+import { AddListingDto, Listing } from '@tf2-automatic/bptf-manager-data';
+
+jest.mock('eventemitter2');
+jest.mock('redlock', () => jest.fn().mockImplementation(() => mock.redlock));
+
+describe('DesiredListingsListener', () => {
+  let service: DesiredListingsListener;
+  let mockEventEmitter: EventEmitter2;
+
+  jest.spyOn(Date, 'now').mockReturnValue(0);
+
+  beforeEach(async () => {
+    jest.clearAllMocks();
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        DesiredListingsService,
+        DesiredListingsListener,
+        {
+          provide: getRedisToken('default'),
+          useValue: mock.redis,
+        },
+      ],
+      imports: [EventEmitterModule.forRoot()],
+    }).compile();
+
+    service = module.get<DesiredListingsListener>(DesiredListingsListener);
+    mockEventEmitter = module.get<EventEmitter2>(EventEmitter2);
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+
+  it('should add errors to listings when they failed to be created', async () => {
+    const steamid = new SteamID('76561198120070906');
+
+    const listing = {
+      id: '1234',
+      currencies: {
+        keys: 1,
+      },
+    };
+
+    const hash = hashListing(listing);
+
+    const desired = new DesiredListingClass(hash, steamid, listing, 0);
+
+    jest
+      .spyOn(DesiredListingsService.prototype, 'getDesiredByHashesNew')
+      .mockResolvedValue(new Map([[desired.getHash(), desired]]));
+
+    await service.currentListingsFailed({
+      steamid,
+      errors: {
+        [hash]: ListingError.ItemDoesNotExist,
+      },
+    });
+
+    const saved: DesiredListing = {
+      id: undefined,
+      hash,
+      steamid64: steamid.getSteamID64(),
+      listing,
+      error: ListingError.ItemDoesNotExist,
+      lastAttemptedAt: 0,
+      updatedAt: 0,
+    };
+
+    expect(mock.redis.hset).toHaveBeenCalledTimes(1);
+    expect(mock.redis.hset).toHaveBeenCalledWith(
+      'bptf-manager:data:listings:desired:' + steamid.getSteamID64(),
+      hash,
+      JSON.stringify(saved),
+    );
+    expect(mock.redis.exec).toHaveBeenCalledTimes(1);
+  });
+
+  it('should remove ids from all desired listings when all current listings are deleted', async () => {
+    const steamid = new SteamID('76561198120070906');
+
+    const listing = {
+      id: '1234',
+      currencies: {
+        keys: 1,
+      },
+    };
+
+    const hash = hashListing(listing);
+
+    const desired = new DesiredListingClass(hash, steamid, listing, 0);
+    desired.setID('1234');
+
+    jest
+      .spyOn(DesiredListingsService.prototype, 'getAllDesiredInternalNew')
+      .mockResolvedValue([desired]);
+
+    await service.currentListingsDeletedAll(steamid);
+
+    // Can't compare it to desired.toJSON() because it is the same object
+    // and it is modified by the listener
+    const saved: DesiredListing = {
+      id: undefined,
+      hash,
+      steamid64: steamid.getSteamID64(),
+      listing,
+      updatedAt: 0,
+      error: undefined,
+    };
+
+    expect(mock.redis.hset).toHaveBeenCalledTimes(1);
+    expect(mock.redis.hset).toHaveBeenCalledWith(
+      'bptf-manager:data:listings:desired:' + steamid.getSteamID64(),
+      hash,
+      JSON.stringify(saved),
+    );
+    expect(mock.redis.exec).toHaveBeenCalledTimes(1);
+  });
+
+  it('should update ids when listings are created', async () => {
+    const steamid = new SteamID('76561198120070906');
+
+    // Listing that is going to be created
+    const listing: AddListingDto = {
+      id: '1234',
+      currencies: {
+        keys: 1,
+      },
+    };
+
+    const hash = hashListing(listing);
+
+    // The desired listing that we will create a listing for
+    const desired = new DesiredListingClass(hash, steamid, listing, 0);
+
+    // Mock that the desired listing exists in the database
+    jest
+      .spyOn(DesiredListingsService.prototype, 'getDesiredByHashesNew')
+      .mockResolvedValue(new Map([[desired.getHash(), desired]]));
+
+    // Current listings
+    const listings: Record<string, Listing> = {
+      [hash]: {
+        id: 'abc123',
+        currencies: {
+          keys: 1,
+        },
+        item: {},
+        archived: false,
+        listedAt: 0,
+        bumpedAt: 0,
+      },
+    };
+
+    // Trigger the function with the hash of the desired listing and the current listing
+    await service.currentListingsCreated({
+      steamid,
+      listings,
+    });
+
+    // The listing that is going to be saved to the database
+    const saved: DesiredListing = {
+      hash,
+      id: 'abc123',
+      steamid64: steamid.getSteamID64(),
+      listing,
+      lastAttemptedAt: 0,
+      updatedAt: 0,
+      error: undefined,
+    };
+
+    // Check if the desired listing is saved to the database
+    expect(mock.redis.hset).toHaveBeenCalledTimes(1);
+    expect(mock.redis.hset).toHaveBeenCalledWith(
+      'bptf-manager:data:listings:desired:' + steamid.getSteamID64(),
+      hash,
+      JSON.stringify(saved),
+    );
+    expect(mock.redis.exec).toHaveBeenCalledTimes(1);
+
+    // Check if the event is emitted
+    expect(mockEventEmitter.emitAsync).toHaveBeenCalledTimes(1);
+    expect(mockEventEmitter.emitAsync).toHaveBeenCalledWith(
+      'desired-listings.created',
+      {
+        steamid: steamid,
+        desired: [saved],
+        listings,
+      },
+    );
+  });
+});

--- a/apps/bptf-manager/src/listings/listeners/desired-listings.listener.ts
+++ b/apps/bptf-manager/src/listings/listeners/desired-listings.listener.ts
@@ -1,0 +1,130 @@
+import { Injectable } from '@nestjs/common';
+import { DesiredListingsService } from '../desired-listings.service';
+import { EventEmitter2, OnEvent } from '@nestjs/event-emitter';
+import {
+  CurrentListingsCreateFailedEvent,
+  CurrentListingsCreatedEvent,
+  DesiredListingsCreatedEvent,
+} from '../interfaces/events.interface';
+import { Redis } from 'ioredis';
+import { InjectRedis } from '@songkeys/nestjs-redis';
+import SteamID from 'steamid';
+
+@Injectable()
+export class DesiredListingsListener {
+  constructor(
+    private readonly desiredListingsService: DesiredListingsService,
+    @InjectRedis() private readonly redis: Redis,
+    private readonly eventEmitter: EventEmitter2,
+  ) {}
+
+  @OnEvent('current-listings.failed', { suppressErrors: false })
+  async currentListingsFailed(
+    event: CurrentListingsCreateFailedEvent,
+  ): Promise<void> {
+    const now = Math.floor(Date.now() / 1000);
+
+    const failedHashes = Object.keys(event.errors);
+
+    // Update the failed desired listings with the error message
+    const map = await this.desiredListingsService.getDesiredByHashesNew(
+      event.steamid,
+      failedHashes,
+    );
+
+    if (map.size === 0) {
+      return;
+    }
+
+    const desired = Array.from(map.values());
+    desired.forEach((desired) => {
+      desired.setUpdatedAt(now);
+      desired.setLastAttemptedAt(now);
+      desired.setError(event.errors[desired.getHash()]);
+    });
+
+    const transaction = this.redis.multi();
+    DesiredListingsService.chainableSaveDesired(
+      transaction,
+      event.steamid,
+      desired,
+    );
+    await transaction.exec();
+  }
+
+  @OnEvent('current-listings.deleted-all', {
+    suppressErrors: false,
+  })
+  async currentListingsDeletedAll(steamid: SteamID): Promise<void> {
+    const now = Math.floor(Date.now() / 1000);
+
+    const desired =
+      await this.desiredListingsService.getAllDesiredInternalNew(steamid);
+
+    if (desired.length === 0) {
+      return;
+    }
+
+    // Remove listing id from all desired listings
+    desired.forEach((d) => {
+      d.setID(undefined);
+      d.setUpdatedAt(now);
+    });
+
+    const transaction = this.redis.multi();
+    DesiredListingsService.chainableSaveDesired(transaction, steamid, desired);
+    await transaction.exec();
+  }
+
+  @OnEvent('current-listings.created', {
+    suppressErrors: false,
+  })
+  async currentListingsCreated(
+    event: CurrentListingsCreatedEvent,
+  ): Promise<void> {
+    const createdHashes = Object.keys(event.listings);
+
+    if (createdHashes.length === 0) {
+      return;
+    }
+
+    const now = Math.floor(Date.now() / 1000);
+
+    // Update desired listings that were changed
+    const hashes = Object.keys(event.listings);
+
+    const map = await this.desiredListingsService.getDesiredByHashesNew(
+      event.steamid,
+      hashes,
+    );
+
+    if (map.size === 0) {
+      return;
+    }
+
+    const desired = Array.from(map.values());
+    desired.forEach((desired) => {
+      desired.setID(event.listings[desired.getHash()].id);
+      desired.setLastAttemptedAt(now);
+      desired.setUpdatedAt(now);
+      desired.setError(undefined);
+    });
+
+    const transaction = this.redis.multi();
+
+    // Save listings with their new listings id
+    DesiredListingsService.chainableSaveDesired(
+      transaction,
+      event.steamid,
+      desired,
+    );
+
+    await transaction.exec();
+
+    await this.eventEmitter.emitAsync('desired-listings.created', {
+      steamid: event.steamid,
+      desired: desired.map((d) => d.toJSON()),
+      listings: event.listings,
+    } satisfies DesiredListingsCreatedEvent);
+  }
+}

--- a/apps/bptf-manager/src/listings/listings.module.ts
+++ b/apps/bptf-manager/src/listings/listings.module.ts
@@ -13,6 +13,7 @@ import { ListingLimitsService } from './listing-limits.service';
 import { InventoriesModule } from '../inventories/inventories.module';
 import { DefaultJobOptions } from 'bullmq';
 import { GetListingsProcessor } from './processors/get-listings.processor';
+import { DesiredListingsListener } from './listeners/desired-listings.listener';
 
 const defaultJobOptions: DefaultJobOptions = {
   attempts: Number.MAX_SAFE_INTEGER,
@@ -51,6 +52,7 @@ const defaultJobOptions: DefaultJobOptions = {
     ManageListingsProcessor,
     ListingLimitsProcessor,
     GetListingsProcessor,
+    DesiredListingsListener,
   ],
   controllers: [ListingsController],
 })

--- a/libs/testing/.eslintrc.json
+++ b/libs/testing/.eslintrc.json
@@ -1,0 +1,18 @@
+{
+  "extends": ["../../.eslintrc.json"],
+  "ignorePatterns": ["!**/*"],
+  "overrides": [
+    {
+      "files": ["*.ts", "*.tsx", "*.js", "*.jsx"],
+      "rules": {}
+    },
+    {
+      "files": ["*.ts", "*.tsx"],
+      "rules": {}
+    },
+    {
+      "files": ["*.js", "*.jsx"],
+      "rules": {}
+    }
+  ]
+}

--- a/libs/testing/README.md
+++ b/libs/testing/README.md
@@ -1,0 +1,7 @@
+# testing
+
+This library was generated with [Nx](https://nx.dev).
+
+## Running unit tests
+
+Run `nx test testing` to execute the unit tests via [Jest](https://jestjs.io).

--- a/libs/testing/jest.config.ts
+++ b/libs/testing/jest.config.ts
@@ -1,0 +1,11 @@
+/* eslint-disable */
+export default {
+  displayName: 'testing',
+  preset: '../../jest.preset.js',
+  testEnvironment: 'node',
+  transform: {
+    '^.+\\.[tj]s$': ['ts-jest', { tsconfig: '<rootDir>/tsconfig.spec.json' }],
+  },
+  moduleFileExtensions: ['ts', 'js', 'html'],
+  coverageDirectory: '../../coverage/libs/testing',
+};

--- a/libs/testing/project.json
+++ b/libs/testing/project.json
@@ -1,0 +1,20 @@
+{
+  "name": "testing",
+  "$schema": "../../node_modules/nx/schemas/project-schema.json",
+  "sourceRoot": "libs/testing/src",
+  "projectType": "library",
+  "targets": {
+    "lint": {
+      "executor": "@nx/eslint:lint",
+      "outputs": ["{options.outputFile}"]
+    },
+    "test": {
+      "executor": "@nx/jest:jest",
+      "outputs": ["{workspaceRoot}/coverage/{projectRoot}"],
+      "options": {
+        "jestConfig": "libs/testing/jest.config.ts"
+      }
+    }
+  },
+  "tags": []
+}

--- a/libs/testing/src/index.ts
+++ b/libs/testing/src/index.ts
@@ -1,0 +1,1 @@
+export * as mock from './mocks';

--- a/libs/testing/src/mocks/index.ts
+++ b/libs/testing/src/mocks/index.ts
@@ -1,0 +1,2 @@
+export * from './redis.mock';
+export * from './redlock.mock';

--- a/libs/testing/src/mocks/redis.mock.ts
+++ b/libs/testing/src/mocks/redis.mock.ts
@@ -1,0 +1,9 @@
+import { jest } from '@jest/globals';
+import Redis from 'ioredis';
+
+export const redis: Partial<{ [K in keyof Redis] }> = {
+  multi: jest.fn().mockReturnThis(),
+  hset: jest.fn(),
+  hdel: jest.fn(),
+  exec: jest.fn(),
+};

--- a/libs/testing/src/mocks/redlock.mock.spec.ts
+++ b/libs/testing/src/mocks/redlock.mock.spec.ts
@@ -1,0 +1,11 @@
+import { redlock } from './redlock.mock';
+
+describe('RedlockMock', () => {
+  it('should call the function provided to the using method', async () => {
+    const result = await redlock.using('abc', 123, async () => {
+      return 'it works';
+    });
+
+    expect(result).toBe('it works');
+  });
+});

--- a/libs/testing/src/mocks/redlock.mock.ts
+++ b/libs/testing/src/mocks/redlock.mock.ts
@@ -1,0 +1,24 @@
+import { jest } from '@jest/globals';
+import Redlock, { RedlockAbortSignal } from 'redlock';
+
+const mockUsing: jest.Mock = jest
+  .fn()
+  .mockImplementation(
+    async (
+      _: unknown,
+      __: unknown,
+      callback: (signal: Partial<RedlockAbortSignal>) => Promise<unknown>,
+    ) => {
+      return Promise.resolve().then(() => {
+        return callback({ aborted: false });
+      });
+    },
+  );
+
+jest.mock('redlock', () => {
+  return jest.fn().mockImplementation(() => redlock);
+});
+
+export const redlock: Partial<{ [K in keyof Redlock] }> = {
+  using: mockUsing,
+};

--- a/libs/testing/tsconfig.json
+++ b/libs/testing/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "module": "commonjs",
+  },
+  "files": [],
+  "include": [],
+  "references": [
+    {
+      "path": "./tsconfig.lib.json",
+    },
+    {
+      "path": "./tsconfig.spec.json",
+    },
+  ],
+}

--- a/libs/testing/tsconfig.lib.json
+++ b/libs/testing/tsconfig.lib.json
@@ -1,0 +1,11 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "module": "commonjs",
+    "outDir": "../../dist/out-tsc",
+    "declaration": true,
+    "types": ["node"]
+  },
+  "exclude": ["jest.config.ts", "src/**/*.spec.ts", "src/**/*.test.ts"],
+  "include": ["src/**/*.ts"]
+}

--- a/libs/testing/tsconfig.spec.json
+++ b/libs/testing/tsconfig.spec.json
@@ -1,0 +1,14 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "../../dist/out-tsc",
+    "module": "commonjs",
+    "types": ["jest", "node"]
+  },
+  "include": [
+    "jest.config.ts",
+    "src/**/*.test.ts",
+    "src/**/*.spec.ts",
+    "src/**/*.d.ts"
+  ]
+}

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
   "devDependencies": {
     "@commitlint/cli": "^18.4.4",
     "@commitlint/config-conventional": "^18.4.4",
+    "@jest/globals": "^29.7.0",
     "@nestjs/schematics": "^10.1.0",
     "@nestjs/testing": "^10.3.0",
     "@nrwl/cli": "15.9.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -164,6 +164,9 @@ devDependencies:
   '@commitlint/config-conventional':
     specifier: ^18.4.4
     version: 18.4.4
+  '@jest/globals':
+    specifier: ^29.7.0
+    version: 29.7.0
   '@nestjs/schematics':
     specifier: ^10.1.0
     version: 10.1.0(typescript@5.3.3)
@@ -283,10 +286,10 @@ devDependencies:
     version: 6.19.0(eslint@8.56.0)(typescript@5.3.3)
   commitizen:
     specifier: ^4.3.0
-    version: 4.3.0(typescript@5.3.3)
+    version: 4.3.0(@types/node@20.11.5)(typescript@5.3.3)
   cz-conventional-changelog:
     specifier: ^3.3.0
-    version: 3.3.0(typescript@5.3.3)
+    version: 3.3.0(@types/node@20.11.5)(typescript@5.3.3)
   eslint:
     specifier: ~8.56.0
     version: 8.56.0
@@ -1724,16 +1727,6 @@ packages:
       conventional-changelog-conventionalcommits: 7.0.2
     dev: true
 
-  /@commitlint/config-validator@18.4.3:
-    resolution: {integrity: sha512-FPZZmTJBARPCyef9ohRC9EANiQEKSWIdatx5OlgeHKu878dWwpyeFauVkhzuBRJFcCA4Uvz/FDtlDKs008IHcA==}
-    engines: {node: '>=v18'}
-    requiresBuild: true
-    dependencies:
-      '@commitlint/types': 18.4.3
-      ajv: 8.12.0
-    dev: true
-    optional: true
-
   /@commitlint/config-validator@18.4.4:
     resolution: {integrity: sha512-/QI8KIg/h7O0Eus36fPcEcO3QPBcdXuGfZeCF5m15k0EB2bcU8s6pHNTNEa6xz9PrAefHCL+yzRJj7w20T6Mow==}
     engines: {node: '>=v18'}
@@ -1753,13 +1746,6 @@ packages:
       lodash.startcase: 4.4.0
       lodash.upperfirst: 4.3.1
     dev: true
-
-  /@commitlint/execute-rule@18.4.3:
-    resolution: {integrity: sha512-t7FM4c+BdX9WWZCPrrbV5+0SWLgT3kCq7e7/GhHCreYifg3V8qyvO127HF796vyFql75n4TFF+5v1asOOWkV1Q==}
-    engines: {node: '>=v18'}
-    requiresBuild: true
-    dev: true
-    optional: true
 
   /@commitlint/execute-rule@18.4.4:
     resolution: {integrity: sha512-a37Nd3bDQydtg9PCLLWM9ZC+GO7X5i4zJvrggJv5jBhaHsXeQ9ZWdO6ODYR+f0LxBXXNYK3geYXJrCWUCP8JEg==}
@@ -1791,28 +1777,6 @@ packages:
       '@commitlint/rules': 18.4.4
       '@commitlint/types': 18.4.4
     dev: true
-
-  /@commitlint/load@18.4.3(typescript@5.3.3):
-    resolution: {integrity: sha512-v6j2WhvRQJrcJaj5D+EyES2WKTxPpxENmNpNG3Ww8MZGik3jWRXtph0QTzia5ZJyPh2ib5aC/6BIDymkUUM58Q==}
-    engines: {node: '>=v18'}
-    requiresBuild: true
-    dependencies:
-      '@commitlint/config-validator': 18.4.3
-      '@commitlint/execute-rule': 18.4.3
-      '@commitlint/resolve-extends': 18.4.3
-      '@commitlint/types': 18.4.3
-      '@types/node': 18.19.4
-      chalk: 4.1.2
-      cosmiconfig: 8.3.6(typescript@5.3.3)
-      cosmiconfig-typescript-loader: 5.0.0(@types/node@18.19.4)(cosmiconfig@8.3.6)(typescript@5.3.3)
-      lodash.isplainobject: 4.0.6
-      lodash.merge: 4.6.2
-      lodash.uniq: 4.5.0
-      resolve-from: 5.0.0
-    transitivePeerDependencies:
-      - typescript
-    dev: true
-    optional: true
 
   /@commitlint/load@18.4.4(@types/node@20.11.5)(typescript@5.3.3):
     resolution: {integrity: sha512-RaDIa9qwOw2xRJ3Jr2DBXd14rmnHJIX2XdZF4kmoF1rgsg/+7cvrExLSUNAkQUNimyjCn1b/bKX2Omm+GdY0XQ==}
@@ -1858,20 +1822,6 @@ packages:
       minimist: 1.2.8
     dev: true
 
-  /@commitlint/resolve-extends@18.4.3:
-    resolution: {integrity: sha512-30sk04LZWf8+SDgJrbJCjM90gTg2LxsD9cykCFeFu+JFHvBFq5ugzp2eO/DJGylAdVaqxej3c7eTSE64hR/lnw==}
-    engines: {node: '>=v18'}
-    requiresBuild: true
-    dependencies:
-      '@commitlint/config-validator': 18.4.3
-      '@commitlint/types': 18.4.3
-      import-fresh: 3.3.0
-      lodash.mergewith: 4.6.2
-      resolve-from: 5.0.0
-      resolve-global: 1.0.0
-    dev: true
-    optional: true
-
   /@commitlint/resolve-extends@18.4.4:
     resolution: {integrity: sha512-RRpIHSbRnFvmGifVk21Gqazf1QF/yeP+Kkg/e3PlkegcOKd/FGOXp/Kx9cvSO2K7ucSn4GD/oBvgasFoy+NCAw==}
     engines: {node: '>=v18'}
@@ -1906,15 +1856,6 @@ packages:
     dependencies:
       find-up: 5.0.0
     dev: true
-
-  /@commitlint/types@18.4.3:
-    resolution: {integrity: sha512-cvzx+vtY/I2hVBZHCLrpoh+sA0hfuzHwDc+BAFPimYLjJkpHnghQM+z8W/KyLGkygJh3BtI3xXXq+dKjnSWEmA==}
-    engines: {node: '>=v18'}
-    requiresBuild: true
-    dependencies:
-      chalk: 4.1.2
-    dev: true
-    optional: true
 
   /@commitlint/types@18.4.4:
     resolution: {integrity: sha512-/FykLtodD8gKs3+VNkAUwofu4LBHankclj+I8fB2jTRvG6PV7k/OUt4P+VbM7ip853qS4F0g7Z6hLNa6JeMcAQ==}
@@ -4250,14 +4191,6 @@ packages:
       '@types/node': 20.11.5
     dev: true
 
-  /@types/node@18.19.4:
-    resolution: {integrity: sha512-xNzlUhzoHotIsnFoXmJB+yWmBvFZgKCI9TtPIEdYIMM1KWfwuY8zh7wvc1u1OAXlC7dlf6mZVx/s+Y5KfFz19A==}
-    requiresBuild: true
-    dependencies:
-      undici-types: 5.26.5
-    dev: true
-    optional: true
-
   /@types/node@20.11.5:
     resolution: {integrity: sha512-g557vgQjUUfN76MZAN/dt1z3dzcUsimuysco0KeluHgrPdJXkP/XdAURgyO2W9fZWHRtRBiVKzKn8vyOAwlG+w==}
     dependencies:
@@ -5502,7 +5435,7 @@ packages:
   /builtins@5.0.1:
     resolution: {integrity: sha512-qwVpFEHNfhYJIzNRBvd2C1kyo6jz3ZSMPyyuR47OPdiKWlbYnZNyDWuyR175qDnAJLiCo5fBBqPb3RiXgWlkOQ==}
     dependencies:
-      semver: 7.5.3
+      semver: 7.5.4
     dev: true
 
   /bullmq@4.17.0:
@@ -5843,13 +5776,13 @@ packages:
       repeat-string: 1.6.1
     dev: true
 
-  /commitizen@4.3.0(typescript@5.3.3):
+  /commitizen@4.3.0(@types/node@20.11.5)(typescript@5.3.3):
     resolution: {integrity: sha512-H0iNtClNEhT0fotHvGV3E9tDejDeS04sN1veIebsKYGMuGscFaswRoYJKmT3eW85eIJAs0F28bG2+a/9wCOfPw==}
     engines: {node: '>= 12'}
     hasBin: true
     dependencies:
       cachedir: 2.3.0
-      cz-conventional-changelog: 3.3.0(typescript@5.3.3)
+      cz-conventional-changelog: 3.3.0(@types/node@20.11.5)(typescript@5.3.3)
       dedent: 0.7.0
       detect-indent: 6.1.0
       find-node-modules: 2.1.3
@@ -5863,6 +5796,7 @@ packages:
       strip-bom: 4.0.0
       strip-json-comments: 3.1.1
     transitivePeerDependencies:
+      - '@types/node'
       - typescript
     dev: true
 
@@ -6039,21 +5973,6 @@ packages:
     dependencies:
       object-assign: 4.1.1
       vary: 1.1.2
-
-  /cosmiconfig-typescript-loader@5.0.0(@types/node@18.19.4)(cosmiconfig@8.3.6)(typescript@5.3.3):
-    resolution: {integrity: sha512-+8cK7jRAReYkMwMiG+bxhcNKiHJDM6bR9FD/nGBXOWdMLuYawjF5cGrtLilJ+LGd3ZjCXnJjR5DkfWPoIVlqJA==}
-    engines: {node: '>=v16'}
-    peerDependencies:
-      '@types/node': '*'
-      cosmiconfig: '>=8.2'
-      typescript: '>=4'
-    dependencies:
-      '@types/node': 18.19.4
-      cosmiconfig: 8.3.6(typescript@5.3.3)
-      jiti: 1.21.0
-      typescript: 5.3.3
-    dev: true
-    optional: true
 
   /cosmiconfig-typescript-loader@5.0.0(@types/node@20.11.5)(cosmiconfig@8.3.6)(typescript@5.3.3):
     resolution: {integrity: sha512-+8cK7jRAReYkMwMiG+bxhcNKiHJDM6bR9FD/nGBXOWdMLuYawjF5cGrtLilJ+LGd3ZjCXnJjR5DkfWPoIVlqJA==}
@@ -6351,19 +6270,20 @@ packages:
     resolution: {integrity: sha512-d4ZVpCW31eWwCMe1YT3ur7mUDnTXbgwyzaL320DrcRT45rfjYxkt5QWLrmOJ+/UEAI2+fQgKe/fCjR8l4TpRgw==}
     dev: false
 
-  /cz-conventional-changelog@3.3.0(typescript@5.3.3):
+  /cz-conventional-changelog@3.3.0(@types/node@20.11.5)(typescript@5.3.3):
     resolution: {integrity: sha512-U466fIzU5U22eES5lTNiNbZ+d8dfcHcssH4o7QsdWaCcRs/feIPCxKYSWkYBNs5mny7MvEfwpTLWjvbm94hecw==}
     engines: {node: '>= 10'}
     dependencies:
       chalk: 2.4.2
-      commitizen: 4.3.0(typescript@5.3.3)
+      commitizen: 4.3.0(@types/node@20.11.5)(typescript@5.3.3)
       conventional-commit-types: 3.0.0
       lodash.map: 4.6.0
       longest: 2.0.1
       word-wrap: 1.2.5
     optionalDependencies:
-      '@commitlint/load': 18.4.3(typescript@5.3.3)
+      '@commitlint/load': 18.4.4(@types/node@20.11.5)(typescript@5.3.3)
     transitivePeerDependencies:
+      - '@types/node'
       - typescript
     dev: true
 

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -35,7 +35,8 @@
       "@tf2-automatic/swagger": ["libs/swagger/src/index.ts"],
       "@tf2-automatic/transactional-outbox": [
         "libs/transactional-outbox/src/index.ts"
-      ]
+      ],
+      "@tf2-automatic/testing": ["libs/testing/src/index.ts"]
     }
   },
   "exclude": ["node_modules", "tmp"]


### PR DESCRIPTION
Move listeners to seperate service to make the methods public so that it is easier to test and won't clutter the DesiredListingsService with methods that should not be called. Could also move the listener service into a seperate module so that it can't be imported at all but it is not that important.