### PR TITLE
feat(bot): publish events to redis or rabbitmq

### DIFF
--- a/apps/bot/README.md
+++ b/apps/bot/README.md
@@ -2,6 +2,12 @@
 
 The bot allows a Steam account to be controlled using a HTTP API. One bot can control one Steam account.
 
+## Events
+
+Events can either be published to RabbitMQ or Redis and it is configured using environment variables.
+
+If you choose to use Redis for events, then you can choose to either persist the events, or just publish them directly. If you persist events, then all events are saved to a list with the key `BOT_EXCHANGE_NAME` from the `bot-data` library and a message is published to a channel also named after `BOT_EXCHANGE_NAME` to notify you that a new event is added to the list. If you choose to not persist events, then all events are published directly to the channel called `BOT_EXCHANGE_NAME`. An example of how to use this can be seen [here](../../examples/redis-events/). When using Redis for events, the `bot-manager` will not work properly because it does not support Redis events.
+
 ## Configuration
 
 The bot is configured using environment variables. Below is a list of the environment variables.
@@ -19,11 +25,18 @@ The bot is configured using environment variables. Below is a list of the enviro
 | TRADE_PENDING_CANCEL_TIME | Milliseconds a sent offer may be pending for before it is canceled. Disabled if no value | No |  |
 | TRADE_POLL_INTERVAL | Milliseconds between getting the current state of recent trades. Use `-1` to disable | No | `30000` |
 | TRADE_POLL_FULL_UPDATE_INTERVAL | Milliseconds between getting the current state of all trades. Disabled if no value | No | `120000` |
-| RABBITMQ_HOST | Address of the RabbitMQ server | Yes |  |
-| RABBITMQ_PORT | Port of the RabbitMQ server | Yes |  |
-| RABBITMQ_USERNAME | Username to authenticate with the RabbitMQ server | Yes |  |
-| RABBITMQ_PASSWORD | Password to authenticate with the RabbitMQ server | Yes |  |
-| RABBITMQ_VHOST | Virtual host to use with the Rabbitmq server | Yes |  |
+| EVENTS_TYPE | How events should be published, either using "rabbitmq" or "redis" | Yes |  |
+| EVENTS_RABBITMQ_HOST | Address of the RabbitMQ server | If "rabbitmq" events type |  |
+| EVENTS_RABBITMQ_PORT | Port of the RabbitMQ server | If "rabbitmq" events type |  |
+| EVENTS_RABBITMQ_USERNAME | Username to authenticate with the RabbitMQ server | If "rabbitmq" events type |  |
+| EVENTS_RABBITMQ_PASSWORD | Password to authenticate with the RabbitMQ server | If "rabbitmq" events type |  |
+| EVENTS_RABBITMQ_VHOST | Virtual host to use with the Rabbitmq server | If "rabbitmq" events type |  |
+| EVENTS_REDIS_HOST | Address of the Redis server | If "redis" events type |  |
+| EVENTS_REDIS_PORT | Port of the Redis server | If "redis" events type |  |
+| EVENTS_REDIS_PASSWORD | Password to authenticate with the Redis server | If "redis" events type |  |
+| EVENTS_REDIS_DB | Database to use with the Redis server | No |  |
+| EVENTS_REDIS_KEY_PREFIX | A prefix for all keys saved in Redis | No |  |
+| EVENTS_REDIS_PERSIST | If events should be persisted to a list or not | If "redis" events type |  |
 | STORAGE_TYPE | Type of storage the bot will use (local or s3) | Yes |  |
 | STORAGE_LOCAL_PATH | Path to storage directory | If "local" storage type |  |
 | STORAGE_S3_ENDPOINT | Endpoint of the S3 service | If "s3" storage type |  |

--- a/apps/bot/src/app.module.ts
+++ b/apps/bot/src/app.module.ts
@@ -39,7 +39,7 @@ import { PrometheusModule } from '@willsoto/nestjs-prometheus';
     TF2Module,
     TradesModule,
     ProfileModule,
-    EventsModule,
+    EventsModule.forRoot(),
     MetadataModule,
     EscrowModule,
     ShutdownModule,

--- a/apps/bot/src/common/config/validation.ts
+++ b/apps/bot/src/common/config/validation.ts
@@ -1,14 +1,24 @@
 import * as Joi from 'joi';
 
-const whenS3 = {
+const whenStorageTypeS3 = {
   is: 's3',
   then: Joi.required(),
 };
 
-const whenLocal = {
+const whenStorageTypeLocal = {
   is: 'local',
   then: Joi.required(),
 };
+
+const whenEventsTypeRabbitMQ = {
+  is: 'rabbitmq',
+  then: Joi.required(),
+};
+
+const whenEventsTypeRedis = (required = true) => ({
+  is: 'redis',
+  then: required ? Joi.required() : Joi.optional(),
+});
 
 const whenManager = {
   is: true,
@@ -38,21 +48,63 @@ const validation = Joi.object({
   TRADE_PENDING_CANCEL_TIME: Joi.number().integer().positive().optional(),
   TRADE_POLL_INTERVAL: Joi.number().integer().allow(-1).positive().optional(),
   TRADE_POLL_FULL_UPDATE_INTERVAL: Joi.number().positive().optional(),
-  RABBITMQ_HOST: Joi.string().required(),
-  RABBITMQ_PORT: Joi.number().integer().required(),
-  RABBITMQ_USERNAME: Joi.string().required(),
-  RABBITMQ_PASSWORD: Joi.string().required(),
-  RABBITMQ_VHOST: Joi.string().allow('').required(),
+  EVENTS_TYPE: Joi.string().valid('rabbitmq', 'redis').required(),
+  EVENTS_RABBITMQ_HOST: Joi.string().when(
+    'EVENTS_TYPE',
+    whenEventsTypeRabbitMQ,
+  ),
+  EVENTS_RABBITMQ_PORT: Joi.number()
+    .integer()
+    .when('EVENTS_TYPE', whenEventsTypeRabbitMQ),
+  EVENTS_RABBITMQ_USERNAME: Joi.string().when(
+    'EVENTS_TYPE',
+    whenEventsTypeRabbitMQ,
+  ),
+  EVENTS_RABBITMQ_PASSWORD: Joi.string().when(
+    'EVENTS_TYPE',
+    whenEventsTypeRabbitMQ,
+  ),
+  EVENTS_RABBITMQ_VHOST: Joi.string()
+    .allow('')
+    .when('EVENTS_TYPE', whenEventsTypeRabbitMQ),
+  EVENTS_REDIS_HOST: Joi.string().when(
+    'EVENTS_TYPE',
+    whenEventsTypeRedis(true),
+  ),
+  EVENTS_REDIS_PORT: Joi.number()
+    .integer()
+    .when('EVENTS_TYPE', whenEventsTypeRedis(true)),
+  EVENTS_REDIS_PASSWORD: Joi.string().when(
+    'EVENTS_TYPE',
+    whenEventsTypeRedis(false),
+  ),
+  EVENTS_REDIS_DB: Joi.number()
+    .integer()
+    .when('EVENTS_TYPE', whenEventsTypeRedis(false)),
+  EVENTS_REDIS_KEY_PREFIX: Joi.string().when(
+    'EVENTS_TYPE',
+    whenEventsTypeRedis(false),
+  ),
+  EVENTS_REDIS_PERSIST: Joi.boolean().when(
+    'EVENTS_TYPE',
+    whenEventsTypeRedis(true),
+  ),
   DEBUG: Joi.boolean().optional(),
   STORAGE_TYPE: Joi.string().valid('local', 's3').required(),
-  STORAGE_LOCAL_PATH: Joi.string().when('STORAGE_TYPE', whenLocal),
-  STORAGE_S3_ENDPOINT: Joi.string().when('STORAGE_TYPE', whenS3),
-  STORAGE_S3_PORT: Joi.number().when('STORAGE_TYPE', whenS3),
-  STORAGE_S3_USE_SSL: Joi.boolean().when('STORAGE_TYPE', whenS3),
-  STORAGE_S3_PATH: Joi.string().when('STORAGE_TYPE', whenS3),
-  STORAGE_S3_ACCESS_KEY_ID: Joi.string().when('STORAGE_TYPE', whenS3),
-  STORAGE_S3_SECRET_ACCESS_KEY: Joi.string().when('STORAGE_TYPE', whenS3),
-  STORAGE_S3_BUCKET: Joi.string().when('STORAGE_TYPE', whenS3),
+  STORAGE_LOCAL_PATH: Joi.string().when('STORAGE_TYPE', whenStorageTypeLocal),
+  STORAGE_S3_ENDPOINT: Joi.string().when('STORAGE_TYPE', whenStorageTypeS3),
+  STORAGE_S3_PORT: Joi.number().when('STORAGE_TYPE', whenStorageTypeS3),
+  STORAGE_S3_USE_SSL: Joi.boolean().when('STORAGE_TYPE', whenStorageTypeS3),
+  STORAGE_S3_PATH: Joi.string().when('STORAGE_TYPE', whenStorageTypeS3),
+  STORAGE_S3_ACCESS_KEY_ID: Joi.string().when(
+    'STORAGE_TYPE',
+    whenStorageTypeS3,
+  ),
+  STORAGE_S3_SECRET_ACCESS_KEY: Joi.string().when(
+    'STORAGE_TYPE',
+    whenStorageTypeS3,
+  ),
+  STORAGE_S3_BUCKET: Joi.string().when('STORAGE_TYPE', whenStorageTypeS3),
   BOT_MANAGER_ENABLED: Joi.boolean().optional(),
   BOT_MANAGER_URL: Joi.string()
     .uri({

--- a/apps/bot/src/events/custom/custom.interface.ts
+++ b/apps/bot/src/events/custom/custom.interface.ts
@@ -1,0 +1,5 @@
+import { BaseEvent } from '@tf2-automatic/bot-data';
+
+export interface CustomEventsService {
+  publish(event: string, data: BaseEvent<unknown>): Promise<void>;
+}

--- a/apps/bot/src/events/custom/rabbitmq-events.service.ts
+++ b/apps/bot/src/events/custom/rabbitmq-events.service.ts
@@ -1,0 +1,20 @@
+import { AmqpConnection } from '@golevelup/nestjs-rabbitmq';
+import { Injectable, OnModuleDestroy } from '@nestjs/common';
+import type { ConfirmChannel } from 'amqplib';
+import { BaseEvent, BOT_EXCHANGE_NAME } from '@tf2-automatic/bot-data';
+import { CustomEventsService } from './custom.interface';
+
+@Injectable()
+export class RabbitMQEventsService
+  implements OnModuleDestroy, CustomEventsService
+{
+  constructor(private readonly amqpConnection: AmqpConnection) {}
+
+  async onModuleDestroy(): Promise<void> {
+    return (this.amqpConnection.channel as ConfirmChannel).waitForConfirms();
+  }
+
+  async publish(type: string, data: BaseEvent<unknown>): Promise<void> {
+    await this.amqpConnection.publish(BOT_EXCHANGE_NAME, type, data);
+  }
+}

--- a/apps/bot/src/events/custom/redis-events.service.ts
+++ b/apps/bot/src/events/custom/redis-events.service.ts
@@ -1,0 +1,41 @@
+import { Injectable, OnModuleDestroy } from '@nestjs/common';
+import { BOT_EXCHANGE_NAME, BaseEvent } from '@tf2-automatic/bot-data';
+import { CustomEventsService } from './custom.interface';
+import { InjectRedis } from '@songkeys/nestjs-redis';
+import { Redis } from 'ioredis';
+import { ConfigService } from '@nestjs/config';
+import { Config, RedisEventsConfig } from '../../common/config/configuration';
+
+@Injectable()
+export class RedisEventsService
+  implements OnModuleDestroy, CustomEventsService
+{
+  private readonly persistEvents: boolean;
+
+  constructor(
+    @InjectRedis()
+    private readonly redis: Redis,
+    private readonly configService: ConfigService<Config>,
+  ) {
+    const config = this.configService.getOrThrow<RedisEventsConfig>('events');
+    this.persistEvents = config.persist;
+  }
+
+  async onModuleDestroy(): Promise<void> {
+    await this.redis.quit();
+  }
+
+  async publish(type: string, data: BaseEvent<unknown>): Promise<void> {
+    const event = JSON.stringify(data);
+
+    if (this.persistEvents) {
+      await this.redis
+        .multi()
+        .lpush(BOT_EXCHANGE_NAME, event)
+        .publish(BOT_EXCHANGE_NAME, type)
+        .exec();
+    } else {
+      await this.redis.publish(BOT_EXCHANGE_NAME, event);
+    }
+  }
+}

--- a/apps/bot/src/events/events.module.ts
+++ b/apps/bot/src/events/events.module.ts
@@ -1,33 +1,107 @@
 import { RabbitMQModule } from '@golevelup/nestjs-rabbitmq';
-import { Module } from '@nestjs/common';
+import { DynamicModule, Global, Module } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { BOT_EXCHANGE_NAME } from '@tf2-automatic/bot-data';
-import { Config, RabbitMQConfig } from '../common/config/configuration';
+import {
+  Config,
+  RabbitMQEventsConfig,
+  RedisEventsConfig,
+} from '../common/config/configuration';
 import { MetadataModule } from '../metadata/metadata.module';
 import { EventsService } from './events.service';
+import { RabbitMQEventsService } from './custom/rabbitmq-events.service';
+import { RedisEventsService } from './custom/redis-events.service';
+import { RedisModule } from '@songkeys/nestjs-redis';
 
-@Module({
-  imports: [
-    RabbitMQModule.forRootAsync(RabbitMQModule, {
-      inject: [ConfigService],
-      useFactory: (configService: ConfigService<Config>) => {
-        const rabbitmqConfig =
-          configService.getOrThrow<RabbitMQConfig>('rabbitmq');
+@Global()
+@Module({})
+export class EventsModule {
+  static forRoot(): DynamicModule {
+    if (process.env.EVENTS_TYPE === 'rabbitmq') {
+      return rabbitmq();
+    } else if (process.env.EVENTS_TYPE === 'redis') {
+      return redis();
+    }
 
-        return {
-          exchanges: [
-            {
-              name: BOT_EXCHANGE_NAME,
-              type: 'topic',
-            },
-          ],
-          uri: `amqp://${rabbitmqConfig.username}:${rabbitmqConfig.password}@${rabbitmqConfig.host}:${rabbitmqConfig.port}/${rabbitmqConfig.vhost}`,
-        };
+    throw new Error('Invalid EVENTS_TYPE value');
+  }
+}
+
+function rabbitmq(): DynamicModule {
+  return {
+    module: EventsModule,
+    imports: [
+      RabbitMQModule.forRootAsync(RabbitMQModule, {
+        inject: [ConfigService],
+        useFactory: (configService: ConfigService<Config>) => {
+          const rabbitmqConfig =
+            configService.getOrThrow<RabbitMQEventsConfig>('events');
+
+          return {
+            exchanges: [
+              {
+                name: BOT_EXCHANGE_NAME,
+                type: 'topic',
+              },
+            ],
+            uri: `amqp://${rabbitmqConfig.username}:${rabbitmqConfig.password}@${rabbitmqConfig.host}:${rabbitmqConfig.port}/${rabbitmqConfig.vhost}`,
+          };
+        },
+      }),
+      MetadataModule,
+    ],
+    providers: [
+      EventsService,
+      {
+        provide: 'EVENTS_ENGINE',
+        useClass: RabbitMQEventsService,
       },
-    }),
-    MetadataModule,
-  ],
-  providers: [EventsService],
-  exports: [EventsService],
-})
-export class EventsModule {}
+    ],
+    exports: [EventsService],
+  };
+}
+
+function redis(): DynamicModule {
+  return {
+    module: EventsModule,
+    imports: [
+      RedisModule.forRootAsync({
+        inject: [ConfigService],
+        useFactory: (configService: ConfigService<Config>) => {
+          const redisConfig =
+            configService.getOrThrow<RedisEventsConfig>('events');
+
+          const config = {
+            host: redisConfig.host,
+            port: redisConfig.port,
+            password: redisConfig.password,
+          };
+
+          if (redisConfig.db !== undefined) {
+            config['db'] = redisConfig.db;
+          }
+
+          if (redisConfig.keyPrefix !== undefined) {
+            config['keyPrefix'] = redisConfig.keyPrefix + ':';
+          }
+
+          console.log(config);
+
+          return {
+            readyLog: true,
+            config,
+          };
+        },
+      }),
+      MetadataModule,
+    ],
+    providers: [
+      EventsService,
+      {
+        provide: 'EVENTS_ENGINE',
+        useClass: RedisEventsService,
+      },
+    ],
+    exports: [EventsService],
+  };
+}

--- a/apps/bot/src/events/events.service.ts
+++ b/apps/bot/src/events/events.service.ts
@@ -1,27 +1,19 @@
-import { AmqpConnection } from '@golevelup/nestjs-rabbitmq';
-import { Injectable, OnModuleDestroy } from '@nestjs/common';
-import { ConfigService } from '@nestjs/config';
-import { Config } from '../common/config/configuration';
-import type { ConfirmChannel } from 'amqplib';
+import { Inject, Injectable } from '@nestjs/common';
 import { MetadataService } from '../metadata/metadata.service';
-import { BaseEvent, BOT_EXCHANGE_NAME } from '@tf2-automatic/bot-data';
+import { BaseEvent } from '@tf2-automatic/bot-data';
+import { CustomEventsService } from './custom/custom.interface';
 
 @Injectable()
-export class EventsService implements OnModuleDestroy {
+export class EventsService {
   constructor(
-    private readonly configService: ConfigService<Config>,
-    private readonly amqpConnection: AmqpConnection,
     private readonly metadataService: MetadataService,
+    @Inject('EVENTS_ENGINE') private readonly engine: CustomEventsService,
   ) {}
-
-  async onModuleDestroy(): Promise<void> {
-    return (this.amqpConnection.channel as ConfirmChannel).waitForConfirms();
-  }
 
   async publish(event: string, data: object = {}): Promise<void> {
     const steamid64 = this.metadataService.getSteamID()?.getSteamID64() ?? null;
 
-    await this.amqpConnection.publish(BOT_EXCHANGE_NAME, event, {
+    await this.engine.publish(event, {
       type: event,
       data,
       metadata: {

--- a/apps/bot/src/main.ts
+++ b/apps/bot/src/main.ts
@@ -59,5 +59,3 @@ async function bootstrap() {
 }
 
 bootstrap();
-
-// 2

--- a/examples/bot-data-usage/main.ts
+++ b/examples/bot-data-usage/main.ts
@@ -1,14 +1,13 @@
 import {
-  INVENTORIES_BASE_URL,
+  INVENTORY_FULL_PATH,
   Inventory,
-  INVENTORY_PATH,
 } from '@tf2-automatic/bot-data';
 import axios from 'axios';
 
 const baseUrl = 'http://localhost:3000';
 
 // Construct url from bot-data constants
-const url = `${baseUrl}${INVENTORIES_BASE_URL}${INVENTORY_PATH}`
+const url = `${baseUrl}${INVENTORY_FULL_PATH}`
   // Replace placeholders with actual values
   .replace(':steamid', '76561198120070906')
   .replace(':appid', '440')

--- a/examples/minimum-setup/docker-compose.yml
+++ b/examples/minimum-setup/docker-compose.yml
@@ -35,11 +35,12 @@ services:
       STEAM_SHARED_SECRET: ''
       STEAM_IDENTITY_SECRET: ''
       # RabbitMQ connection details
-      RABBITMQ_HOST: 'rabbitmq'
-      RABBITMQ_PORT: 5672
-      RABBITMQ_USERNAME: 'test'
-      RABBITMQ_PASSWORD: 'test'
-      RABBITMQ_VHOST: ''
+      EVENTS_TYPE: 'rabbitmq'
+      EVENTS_RABBITMQ_HOST: 'rabbitmq'
+      EVENTS_RABBITMQ_PORT: 5672
+      EVENTS_RABBITMQ_USERNAME: 'test'
+      EVENTS_RABBITMQ_PASSWORD: 'test'
+      EVENTS_RABBITMQ_VHOST: ''
       # Storage settings
       STORAGE_TYPE: 'local'
       STORAGE_LOCAL_PATH: '/data'

--- a/examples/rabbitmq/README.md
+++ b/examples/rabbitmq/README.md
@@ -1,4 +1,4 @@
-# RabbitMQ example
+# RabbitMQ events example
 
 This example connects to a RabbitMQ server and listens for all messages made by the bot and bot manager. It creates a queue called `all` and listens for all messages made by the bot and bot manager.
 

--- a/examples/recommended-setup/docker-compose.yml
+++ b/examples/recommended-setup/docker-compose.yml
@@ -121,11 +121,12 @@ services:
       STEAM_SHARED_SECRET: ''
       STEAM_IDENTITY_SECRET: ''
       # RabbitMQ connection details
-      RABBITMQ_HOST: 'rabbitmq'
-      RABBITMQ_PORT: 5672
-      RABBITMQ_USERNAME: 'test'
-      RABBITMQ_PASSWORD: 'test'
-      RABBITMQ_VHOST: ''
+      EVENTS_TYPE: 'rabbitmq'
+      EVENTS_RABBITMQ_HOST: 'rabbitmq'
+      EVENTS_RABBITMQ_PORT: 5672
+      EVENTS_RABBITMQ_USERNAME: 'test'
+      EVENTS_RABBITMQ_PASSWORD: 'test'
+      EVENTS_RABBITMQ_VHOST: ''
       # Storage settings
       STORAGE_TYPE: 's3'
       STORAGE_S3_ENDPOINT: 'minio'

--- a/examples/redis/.npmrc
+++ b/examples/redis/.npmrc
@@ -1,0 +1,2 @@
+@tf2-automatic:registry=https://npm.pkg.github.com
+//npm.pkg.github.com/:_authToken=<GITHUB TOKEN HERE>

--- a/examples/redis/README.md
+++ b/examples/redis/README.md
@@ -1,0 +1,3 @@
+# Redis events example
+
+The file [no-persist.ts](no-persist.ts) shows how to handle events when they are not persisted and [persist.ts](persist.ts) shows how to handle events when they are persisted.

--- a/examples/redis/no-persist.ts
+++ b/examples/redis/no-persist.ts
@@ -1,0 +1,13 @@
+import { Redis } from 'ioredis';
+import { BOT_EXCHANGE_NAME } from '@tf2-automatic/bot-data';
+
+const redis = new Redis();
+
+redis.subscribe(BOT_EXCHANGE_NAME);
+
+redis.on('message', (channel, message) => {
+  if (channel === BOT_EXCHANGE_NAME) {
+    const parsed = JSON.parse(message);
+    console.log(parsed);
+  }
+});

--- a/examples/redis/package.json
+++ b/examples/redis/package.json
@@ -1,0 +1,6 @@
+{
+  "dependencies": {
+    "@tf2-automatic/bot-data": "latest",
+    "ioredis": "^5.4.1"
+  }
+}

--- a/examples/redis/persist.ts
+++ b/examples/redis/persist.ts
@@ -1,0 +1,65 @@
+import { Redis } from 'ioredis';
+import { BOT_EXCHANGE_NAME, BaseEvent } from '@tf2-automatic/bot-data';
+
+const subscriber = new Redis();
+const redis = new Redis();
+
+let reading = false;
+
+subscriber.subscribe(BOT_EXCHANGE_NAME);
+
+subscriber.on('message', (channel) => {
+  if (channel === BOT_EXCHANGE_NAME) {
+    read();
+  }
+});
+
+redis.on('connect', () => {
+  read();
+});
+
+function read() {
+  if (reading) {
+    return;
+  }
+
+  reading = true;
+
+  let repeat = false;
+
+  getAndHandleMessage().then((hasMessage) => {
+    if (hasMessage) {
+      repeat = true;
+    }
+  }).finally(() => {
+    reading = false;
+
+    if (repeat) {
+      read();
+    } else {
+      // Wait for 1 second before retrying
+      setTimeout(read, 1000);
+    }
+  });
+}
+
+async function getAndHandleMessage(): Promise<boolean> {
+  const message = await redis.lindex(BOT_EXCHANGE_NAME, -1);
+  if (!message) {
+    return false;
+  }
+
+  const event = JSON.parse(message) as BaseEvent<unknown>;
+
+  // Handle event
+  handleEvent(event);
+
+  // Remove message from list once handled
+  await redis.lrem(BOT_EXCHANGE_NAME, 1, message);
+
+  return true;
+}
+
+function handleEvent(event: BaseEvent<unknown>) {
+  console.log(event);
+}


### PR DESCRIPTION
The bot can now publish events to Redis or RabbitMQ

BREAKING CHANGE: New environment variables for choosing how to publish events