### PR TITLE
feat: publish validators

### DIFF
--- a/libs/is-refined-validator/.eslintrc.json
+++ b/libs/is-refined-validator/.eslintrc.json
@@ -1,5 +1,5 @@
 {
-  "extends": ["../../.eslintrc.json"],
+  "extends": ["../../.eslintrc.json", "../../.eslintrc.publish.json"],
   "ignorePatterns": ["!**/*"],
   "overrides": [
     {

--- a/libs/is-refined-validator/package.json
+++ b/libs/is-refined-validator/package.json
@@ -1,4 +1,9 @@
 {
   "name": "@tf2-automatic/is-refined-validator",
-  "version": "latest"
+  "version": "latest",
+  "dependencies": {
+    "class-validator": "0.14.1",
+    "tf2-currencies": "1.2.4",
+    "tslib": "2.6.3"
+  }
 }

--- a/libs/is-refined-validator/project.json
+++ b/libs/is-refined-validator/project.json
@@ -8,7 +8,10 @@
       "executor": "@nx/linter:eslint",
       "outputs": ["{options.outputFile}"],
       "options": {
-        "lintFilePatterns": ["libs/is-refined-validator/**/*.ts"]
+        "lintFilePatterns": [
+          "libs/is-refined-validator/**/*.ts",
+          "libs/is-refined-validator/package.json"
+        ]
       }
     },
     "test": {
@@ -34,6 +37,31 @@
         "packageJson": "libs/is-refined-validator/package.json",
         "main": "libs/is-refined-validator/src/index.ts",
         "assets": ["libs/is-refined-validator/*.md"]
+      }
+    },
+    "npm": {
+      "executor": "nx:run-commands",
+      "options": {
+        "commands": [
+          {
+            "command": "if [ \"{args.version}\" = \"undefined\" ]; then exit 1; fi",
+            "forwardAllArgs": false
+          },
+          {
+            "command": "jq '.version=\"{args.version}\"' package.json > package.json.tmp",
+            "forwardAllArgs": false
+          },
+          {
+            "command": "mv package.json.tmp package.json",
+            "forwardAllArgs": false
+          },
+          {
+            "command": "npm publish --tag {args.tag}",
+            "forwardAllArgs": false
+          }
+        ],
+        "cwd": "dist/libs/is-refined-validator/",
+        "parallel": false
       }
     }
   },

--- a/libs/is-steamid-validator/.eslintrc.json
+++ b/libs/is-steamid-validator/.eslintrc.json
@@ -1,5 +1,5 @@
 {
-  "extends": ["../../.eslintrc.json"],
+  "extends": ["../../.eslintrc.json", "../../.eslintrc.publish.json"],
   "ignorePatterns": ["!**/*"],
   "overrides": [
     {

--- a/libs/is-steamid-validator/package.json
+++ b/libs/is-steamid-validator/package.json
@@ -1,4 +1,9 @@
 {
   "name": "@tf2-automatic/is-steamid-validator",
-  "version": "latest"
+  "version": "latest",
+  "dependencies": {
+    "class-validator": "0.14.1",
+    "steamid": "2.0.0",
+    "tslib": "2.6.3"
+  }
 }

--- a/libs/is-steamid-validator/project.json
+++ b/libs/is-steamid-validator/project.json
@@ -8,7 +8,10 @@
       "executor": "@nx/linter:eslint",
       "outputs": ["{options.outputFile}"],
       "options": {
-        "lintFilePatterns": ["libs/is-steamid-validator/**/*.ts"]
+        "lintFilePatterns": [
+          "libs/is-steamid-validator/**/*.ts",
+          "libs/is-steamid-validator/package.json"
+        ]
       }
     },
     "test": {
@@ -34,6 +37,31 @@
         "packageJson": "libs/is-steamid-validator/package.json",
         "main": "libs/is-steamid-validator/src/index.ts",
         "assets": ["libs/is-steamid-validator/*.md"]
+      }
+    },
+    "npm": {
+      "executor": "nx:run-commands",
+      "options": {
+        "commands": [
+          {
+            "command": "if [ \"{args.version}\" = \"undefined\" ]; then exit 1; fi",
+            "forwardAllArgs": false
+          },
+          {
+            "command": "jq '.version=\"{args.version}\"' package.json > package.json.tmp",
+            "forwardAllArgs": false
+          },
+          {
+            "command": "mv package.json.tmp package.json",
+            "forwardAllArgs": false
+          },
+          {
+            "command": "npm publish --tag {args.tag}",
+            "forwardAllArgs": false
+          }
+        ],
+        "cwd": "dist/libs/is-steamid-validator/",
+        "parallel": false
       }
     }
   },

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -30,6 +30,7 @@
       "@tf2-automatic/is-steamid-validator": [
         "libs/is-steamid-validator/src/index.ts"
       ],
+      "@tf2-automatic/nestjs-events": ["libs/nestjs-events/src/index.ts"],
       "@tf2-automatic/nestjs-steamid-pipe": [
         "libs/nestjs-steamid-pipe/src/index.ts"
       ],
@@ -37,8 +38,7 @@
       "@tf2-automatic/testing": ["libs/testing/src/index.ts"],
       "@tf2-automatic/transactional-outbox": [
         "libs/transactional-outbox/src/index.ts"
-      ],
-      "@tf2-automatic/nestjs-events": ["libs/nestjs-events/src/index.ts"]
+      ]
     }
   },
   "exclude": ["node_modules", "tmp"]


### PR DESCRIPTION
Publish refined and steamid validators. This also fixes an issue with missing dependencies for the bptf-manager-data library.