### PR TITLE
fix(bptf-manager-data): missing dependencies

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -58,7 +58,8 @@
           "@tf2-automatic/is-refined-validator",
           "@tf2-automatic/is-steamid-validator",
           "redlock"
-        ], 
+        ],
+        "useLocalPathsForWorkspaceDependencies": true,
         "includeTransitiveDependencies": true,
         "checkMissingDependencies": false
       }

--- a/libs/bptf-manager-data/project.json
+++ b/libs/bptf-manager-data/project.json
@@ -11,7 +11,8 @@
         "outputPath": "dist/libs/bptf-manager-data",
         "main": "libs/bptf-manager-data/src/index.ts",
         "tsConfig": "libs/bptf-manager-data/tsconfig.lib.json",
-        "assets": ["libs/bptf-manager-data/*.md"]
+        "assets": ["libs/bptf-manager-data/*.md"],
+        "external": "none"
       }
     },
     "lint": {
@@ -62,6 +63,9 @@
         "cwd": "dist/libs/bptf-manager-data/",
         "parallel": false
       }
+    },
+    "xd": {
+      "executor": "@tf2-automatic/executors:npm"
     }
   },
   "tags": []

--- a/libs/bptf-manager-data/project.json
+++ b/libs/bptf-manager-data/project.json
@@ -63,9 +63,6 @@
         "cwd": "dist/libs/bptf-manager-data/",
         "parallel": false
       }
-    },
-    "xd": {
-      "executor": "@tf2-automatic/executors:npm"
     }
   },
   "tags": []


### PR DESCRIPTION
Use deprecated "external" build option for bptf-manager-data.