### PR TITLE
fix: correct redis key prefixes

### DIFF
--- a/apps/bot-manager/src/app.module.ts
+++ b/apps/bot-manager/src/app.module.ts
@@ -49,7 +49,7 @@ import { RelayModule } from './relay/relay.module';
         const redisConfig =
           configService.getOrThrow<RedisConfig.Config>('redis');
         return {
-          prefix: redisConfig.keyPrefix + 'bot-manager:bull',
+          prefix: redisConfig.keyPrefix + 'bull',
           connection: {
             host: redisConfig.host,
             port: redisConfig.port,

--- a/apps/bot-manager/src/escrow/escrow.service.ts
+++ b/apps/bot-manager/src/escrow/escrow.service.ts
@@ -15,8 +15,6 @@ import { GetEscrowDto } from '@tf2-automatic/dto';
 
 const ESCROW_EXPIRE_TIME = 24 * 60 * 60;
 
-const KEY_PREFIX = 'bot-manager:data:';
-
 interface EscrowWithTimestamp {
   timestamp: number;
   escrowDays: number;
@@ -84,7 +82,7 @@ export class EscrowService {
       escrowDays: response.data.escrowDays,
     };
 
-    const key = `${KEY_PREFIX}escrow:${steamid.getSteamID64()}`;
+    const key = `escrow:${steamid.getSteamID64()}`;
 
     await this.redis
       .pipeline()
@@ -98,7 +96,7 @@ export class EscrowService {
   async getEscrowFromCache(
     steamid: SteamID,
   ): Promise<EscrowWithTimestamp | null> {
-    const key = `${KEY_PREFIX}escrow:${steamid.getSteamID64()}`;
+    const key = `escrow:${steamid.getSteamID64()}`;
     const object = await this.redis.hgetall(key);
 
     if (Object.keys(object).length === 0) {
@@ -115,6 +113,6 @@ export class EscrowService {
   }
 
   async deleteEscrow(steamid: SteamID): Promise<void> {
-    await this.redis.del(`${KEY_PREFIX}escrow:${steamid.getSteamID64()}`);
+    await this.redis.del(`escrow:${steamid.getSteamID64()}`);
   }
 }

--- a/apps/bot-manager/src/inventories/inventories.service.ts
+++ b/apps/bot-manager/src/inventories/inventories.service.ts
@@ -47,8 +47,6 @@ import { LockDuration, Locker } from '@tf2-automatic/locking';
 
 const INVENTORY_EXPIRE_TIME = 600;
 
-const KEY_PREFIX = 'bot-manager:data:';
-
 @Injectable()
 export class InventoriesService implements OnApplicationBootstrap {
   private readonly locker: Locker;
@@ -611,7 +609,7 @@ export class InventoriesService implements OnApplicationBootstrap {
   }
 
   private getInventoryKey(steamid: SteamID, appid: number, contextid: string) {
-    return `${KEY_PREFIX}inventory:${steamid.getSteamID64()}:${appid}:${contextid}`;
+    return `inventory:${steamid.getSteamID64()}:${appid}:${contextid}`;
   }
 
   private getInventoryKeyFromObject(data: {

--- a/apps/bptf-manager/src/app.module.ts
+++ b/apps/bptf-manager/src/app.module.ts
@@ -43,7 +43,7 @@ import { Redis } from '@tf2-automatic/config';
       useFactory: (configService: ConfigService<Config>) => {
         const redisConfig = configService.getOrThrow<Redis.Config>('redis');
         return {
-          prefix: redisConfig.keyPrefix + 'bptf-manager:bull',
+          prefix: redisConfig.keyPrefix + 'bull',
           connection: {
             host: redisConfig.host,
             port: redisConfig.port,

--- a/apps/bptf-manager/src/inventories/inventories.service.ts
+++ b/apps/bptf-manager/src/inventories/inventories.service.ts
@@ -17,11 +17,7 @@ import {
 import { Redis } from 'ioredis';
 import { InjectRedis } from '@songkeys/nestjs-redis';
 import { Inventory } from './interfaces/inventory.interface';
-import Redlock from 'redlock';
-import { getLockConfig } from '@tf2-automatic/config';
 import { LockDuration, Locker } from '@tf2-automatic/locking';
-
-const KEY_PREFIX = 'bptf-manager:data:';
 
 @Injectable()
 export class InventoriesService {
@@ -168,11 +164,11 @@ export class InventoriesService {
   }
 
   private getInventoryKey(steamid64: string) {
-    return KEY_PREFIX + 'inventories:' + steamid64;
+    return 'inventories:' + steamid64;
   }
 
   private getInventoryRefreshPointKey(steamid64: string) {
-    return KEY_PREFIX + 'inventories:refresh:' + steamid64;
+    return 'inventories:refresh:' + steamid64;
   }
 
   async getInventoryStatus(

--- a/apps/bptf-manager/src/listings/current-listings.service.ts
+++ b/apps/bptf-manager/src/listings/current-listings.service.ts
@@ -36,8 +36,6 @@ import {
 } from './interfaces/get-listings.queue.interface';
 import { DesiredListing } from './classes/desired-listing.class';
 
-const KEY_PREFIX = 'bptf-manager:data:';
-
 export class CurrentListingsService {
   private readonly logger = new Logger(CurrentListingsService.name);
 
@@ -848,7 +846,7 @@ export class CurrentListingsService {
   }
 
   private getCurrentKey(steamid: SteamID): string {
-    return `${KEY_PREFIX}listings:current:${steamid.getSteamID64()}`;
+    return `listings:current:${steamid.getSteamID64()}`;
   }
 
   private getTempCurrentKey(steamid: SteamID, time: number | '*'): string {
@@ -856,7 +854,7 @@ export class CurrentListingsService {
   }
 
   getCurrentShouldNotDeleteEntryKey(steamid: SteamID): string {
-    return `${KEY_PREFIX}listings:current:keep:${steamid.getSteamID64()}`;
+    return `listings:current:keep:${steamid.getSteamID64()}`;
   }
 
   private getResourceForListingId(steamid: SteamID, id: string): string {

--- a/apps/bptf-manager/src/listings/desired-listings.service.spec.ts
+++ b/apps/bptf-manager/src/listings/desired-listings.service.spec.ts
@@ -87,7 +87,7 @@ describe('DesiredListingsService', () => {
 
       expect(mockRedis.hset).toHaveBeenCalledTimes(1);
       expect(mockRedis.hset).toHaveBeenCalledWith(
-        'listings:desired:76561198120070906:' + steamid.getSteamID64(),
+        'listings:desired:' + steamid.getSteamID64(),
         hash,
         JSON.stringify(saved),
       );
@@ -148,7 +148,7 @@ describe('DesiredListingsService', () => {
 
       expect(mockRedis.hset).toHaveBeenCalledTimes(1);
       expect(mockRedis.hset).toHaveBeenCalledWith(
-        'listings:desired:76561198120070906:' + saved.steamid64,
+        'listings:desired:' + saved.steamid64,
         saved.hash,
         JSON.stringify(saved),
       );
@@ -210,7 +210,7 @@ describe('DesiredListingsService', () => {
 
       expect(mockRedis.hset).toHaveBeenCalledTimes(1);
       expect(mockRedis.hset).toHaveBeenCalledWith(
-        'listings:desired:76561198120070906:' + saved.steamid64,
+        'listings:desired:' + saved.steamid64,
         saved.hash,
         JSON.stringify(saved),
       );
@@ -288,7 +288,7 @@ describe('DesiredListingsService', () => {
 
       expect(mockRedis.hdel).toHaveBeenCalledTimes(1);
       expect(mockRedis.hdel).toHaveBeenCalledWith(
-        'listings:desired:76561198120070906:' + steamid.getSteamID64(),
+        'listings:desired:' + steamid.getSteamID64(),
         existingDesired.getHash(),
       );
       expect(mockRedis.exec).toHaveBeenCalledTimes(1);
@@ -335,7 +335,7 @@ describe('DesiredListingsService', () => {
 
       expect(mockRedis.hdel).toHaveBeenCalledTimes(1);
       expect(mockRedis.hdel).toHaveBeenCalledWith(
-        'listings:desired:76561198120070906:' + steamid.getSteamID64(),
+        'listings:desired:' + steamid.getSteamID64(),
         existingDesired.getHash(),
       );
       expect(mockRedis.exec).toHaveBeenCalledTimes(1);
@@ -383,7 +383,7 @@ describe('DesiredListingsService', () => {
 
       expect(mockRedis.hset).toHaveBeenCalledTimes(1);
       expect(mockRedis.hset).toHaveBeenCalledWith(
-        'listings:desired:76561198120070906:' + steamid.getSteamID64(),
+        'listings:desired:' + steamid.getSteamID64(),
         desired.getHash(),
         JSON.stringify(saved),
       );

--- a/apps/bptf-manager/src/listings/desired-listings.service.spec.ts
+++ b/apps/bptf-manager/src/listings/desired-listings.service.spec.ts
@@ -399,7 +399,7 @@ function expectMockUsing(steamid: SteamID, hashes: string[]) {
   expect(mock.redlock.using).toHaveBeenCalledTimes(1);
 
   const resources = hashes.map(
-    (hash) => `desired:${steamid.getSteamID64()}:${hash}`,
+    (hash) => `locking:desired:${steamid.getSteamID64()}:${hash}`,
   );
 
   expect(mock.redlock.using).toHaveBeenCalledWith(

--- a/apps/bptf-manager/src/listings/desired-listings.service.spec.ts
+++ b/apps/bptf-manager/src/listings/desired-listings.service.spec.ts
@@ -87,7 +87,7 @@ describe('DesiredListingsService', () => {
 
       expect(mockRedis.hset).toHaveBeenCalledTimes(1);
       expect(mockRedis.hset).toHaveBeenCalledWith(
-        'bptf-manager:data:listings:desired:' + steamid.getSteamID64(),
+        'listings:desired:76561198120070906:' + steamid.getSteamID64(),
         hash,
         JSON.stringify(saved),
       );
@@ -148,7 +148,7 @@ describe('DesiredListingsService', () => {
 
       expect(mockRedis.hset).toHaveBeenCalledTimes(1);
       expect(mockRedis.hset).toHaveBeenCalledWith(
-        'bptf-manager:data:listings:desired:' + saved.steamid64,
+        'listings:desired:76561198120070906:' + saved.steamid64,
         saved.hash,
         JSON.stringify(saved),
       );
@@ -210,7 +210,7 @@ describe('DesiredListingsService', () => {
 
       expect(mockRedis.hset).toHaveBeenCalledTimes(1);
       expect(mockRedis.hset).toHaveBeenCalledWith(
-        'bptf-manager:data:listings:desired:' + saved.steamid64,
+        'listings:desired:76561198120070906:' + saved.steamid64,
         saved.hash,
         JSON.stringify(saved),
       );
@@ -288,7 +288,7 @@ describe('DesiredListingsService', () => {
 
       expect(mockRedis.hdel).toHaveBeenCalledTimes(1);
       expect(mockRedis.hdel).toHaveBeenCalledWith(
-        'bptf-manager:data:listings:desired:' + steamid.getSteamID64(),
+        'listings:desired:76561198120070906:' + steamid.getSteamID64(),
         existingDesired.getHash(),
       );
       expect(mockRedis.exec).toHaveBeenCalledTimes(1);
@@ -335,7 +335,7 @@ describe('DesiredListingsService', () => {
 
       expect(mockRedis.hdel).toHaveBeenCalledTimes(1);
       expect(mockRedis.hdel).toHaveBeenCalledWith(
-        'bptf-manager:data:listings:desired:' + steamid.getSteamID64(),
+        'listings:desired:76561198120070906:' + steamid.getSteamID64(),
         existingDesired.getHash(),
       );
       expect(mockRedis.exec).toHaveBeenCalledTimes(1);
@@ -383,7 +383,7 @@ describe('DesiredListingsService', () => {
 
       expect(mockRedis.hset).toHaveBeenCalledTimes(1);
       expect(mockRedis.hset).toHaveBeenCalledWith(
-        'bptf-manager:data:listings:desired:' + steamid.getSteamID64(),
+        'listings:desired:76561198120070906:' + steamid.getSteamID64(),
         desired.getHash(),
         JSON.stringify(saved),
       );

--- a/apps/bptf-manager/src/listings/desired-listings.service.ts
+++ b/apps/bptf-manager/src/listings/desired-listings.service.ts
@@ -17,8 +17,6 @@ import hashListing from './utils/desired-listing-hash';
 import { LockDuration, Locker } from '@tf2-automatic/locking';
 import { Injectable } from '@nestjs/common';
 
-const KEY_PREFIX = 'bptf-manager:data:';
-
 @Injectable()
 export class DesiredListingsService {
   private readonly locker: Locker;
@@ -197,6 +195,6 @@ export class DesiredListingsService {
   }
 
   private static getDesiredKey(steamid: SteamID): string {
-    return `${KEY_PREFIX}listings:desired:${steamid.getSteamID64()}`;
+    return `listings:desired:${steamid.getSteamID64()}`;
   }
 }

--- a/apps/bptf-manager/src/listings/listeners/desired-listings.listener.spec.ts
+++ b/apps/bptf-manager/src/listings/listeners/desired-listings.listener.spec.ts
@@ -81,7 +81,7 @@ describe('DesiredListingsListener', () => {
 
     expect(mock.redis.hset).toHaveBeenCalledTimes(1);
     expect(mock.redis.hset).toHaveBeenCalledWith(
-      'listings:desired:76561198120070906:' + steamid.getSteamID64(),
+      'listings:desired:' + steamid.getSteamID64(),
       desired.getHash(),
       JSON.stringify(saved),
     );
@@ -121,7 +121,7 @@ describe('DesiredListingsListener', () => {
 
     expect(mock.redis.hset).toHaveBeenCalledTimes(1);
     expect(mock.redis.hset).toHaveBeenCalledWith(
-      'listings:desired:76561198120070906:' + steamid.getSteamID64(),
+      'listings:desired:' + steamid.getSteamID64(),
       desired.getHash(),
       JSON.stringify(saved),
     );
@@ -182,7 +182,7 @@ describe('DesiredListingsListener', () => {
     // Check if the desired listing is saved to the database
     expect(mock.redis.hset).toHaveBeenCalledTimes(1);
     expect(mock.redis.hset).toHaveBeenCalledWith(
-      'listings:desired:76561198120070906:' + steamid.getSteamID64(),
+      'listings:desired:' + steamid.getSteamID64(),
       desired.getHash(),
       JSON.stringify(saved),
     );

--- a/apps/bptf-manager/src/listings/listeners/desired-listings.listener.spec.ts
+++ b/apps/bptf-manager/src/listings/listeners/desired-listings.listener.spec.ts
@@ -81,7 +81,7 @@ describe('DesiredListingsListener', () => {
 
     expect(mock.redis.hset).toHaveBeenCalledTimes(1);
     expect(mock.redis.hset).toHaveBeenCalledWith(
-      'bptf-manager:data:listings:desired:' + steamid.getSteamID64(),
+      'listings:desired:76561198120070906:' + steamid.getSteamID64(),
       desired.getHash(),
       JSON.stringify(saved),
     );
@@ -121,7 +121,7 @@ describe('DesiredListingsListener', () => {
 
     expect(mock.redis.hset).toHaveBeenCalledTimes(1);
     expect(mock.redis.hset).toHaveBeenCalledWith(
-      'bptf-manager:data:listings:desired:' + steamid.getSteamID64(),
+      'listings:desired:76561198120070906:' + steamid.getSteamID64(),
       desired.getHash(),
       JSON.stringify(saved),
     );
@@ -182,7 +182,7 @@ describe('DesiredListingsListener', () => {
     // Check if the desired listing is saved to the database
     expect(mock.redis.hset).toHaveBeenCalledTimes(1);
     expect(mock.redis.hset).toHaveBeenCalledWith(
-      'bptf-manager:data:listings:desired:' + steamid.getSteamID64(),
+      'listings:desired:76561198120070906:' + steamid.getSteamID64(),
       desired.getHash(),
       JSON.stringify(saved),
     );

--- a/apps/bptf-manager/src/listings/listing-limits.service.ts
+++ b/apps/bptf-manager/src/listings/listing-limits.service.ts
@@ -8,8 +8,6 @@ import { OnEvent } from '@nestjs/event-emitter';
 import { ListingLimits } from '@tf2-automatic/bptf-manager-data';
 import { setTimeout } from 'timers/promises';
 
-const KEY_PREFIX = 'bptf-manager:data:';
-
 @Injectable()
 export class ListingLimitsService {
   private readonly logger = new Logger(ListingLimitsService.name);
@@ -127,6 +125,6 @@ export class ListingLimitsService {
   }
 
   private getLimitsKey(steamid: SteamID): string {
-    return `${KEY_PREFIX}listings:limits:${steamid.getSteamID64()}`;
+    return `listings:limits:${steamid.getSteamID64()}`;
   }
 }

--- a/apps/bptf-manager/src/listings/manage-listings.service.ts
+++ b/apps/bptf-manager/src/listings/manage-listings.service.ts
@@ -36,8 +36,6 @@ enum ListingAction {
   Update,
 }
 
-const KEY_PREFIX = 'bptf-manager:data:';
-
 export class ManageListingsService {
   private readonly logger = new Logger(ManageListingsService.name);
 
@@ -838,18 +836,18 @@ export class ManageListingsService {
   }
 
   private static getCreateKey(steamid: SteamID): string {
-    return `${KEY_PREFIX}listings:create:${steamid.getSteamID64()}`;
+    return `listings:create:${steamid.getSteamID64()}`;
   }
 
   private static getUpdateKey(steamid: SteamID): string {
-    return `${KEY_PREFIX}listings:update:${steamid.getSteamID64()}`;
+    return `listings:update:${steamid.getSteamID64()}`;
   }
 
   private static getDeleteKey(steamid: SteamID): string {
-    return `${KEY_PREFIX}listings:delete:${steamid.getSteamID64()}`;
+    return `listings:delete:${steamid.getSteamID64()}`;
   }
 
   private static getArchivedDeleteKey(steamid: SteamID): string {
-    return `${KEY_PREFIX}listings:delete:archived:${steamid.getSteamID64()}`;
+    return `listings:delete:archived:${steamid.getSteamID64()}`;
   }
 }

--- a/apps/bptf-manager/src/notifications/notifications.service.ts
+++ b/apps/bptf-manager/src/notifications/notifications.service.ts
@@ -11,8 +11,6 @@ import { InjectQueue } from '@nestjs/bullmq';
 import { Queue } from 'bullmq';
 import { JobData } from './interfaces/queue';
 
-const KEY_PREFIX = 'bptf-manager:data:';
-
 @Injectable()
 export class NotificationsService {
   private readonly logger = new Logger(NotificationsService.name);
@@ -147,7 +145,7 @@ export class NotificationsService {
   }
 
   private getKey(steamid: SteamID) {
-    return KEY_PREFIX + 'notifications:' + steamid.getSteamID64();
+    return 'notifications:' + steamid.getSteamID64();
   }
 
   fetchNotifications(

--- a/apps/bptf-manager/src/tokens/tokens.service.ts
+++ b/apps/bptf-manager/src/tokens/tokens.service.ts
@@ -8,8 +8,6 @@ import { SaveTokenDto, Token } from '@tf2-automatic/bptf-manager-data';
 import { Redis } from 'ioredis';
 import SteamID from 'steamid';
 
-const KEY_PREFIX = 'bptf-manager:data:';
-
 @Injectable()
 export class TokensService {
   constructor(@InjectRedis() private readonly redis: Redis) {}
@@ -93,6 +91,6 @@ export class TokensService {
   }
 
   private getKey(steamid64: string) {
-    return KEY_PREFIX + 'tokens:' + steamid64;
+    return 'tokens:' + steamid64;
   }
 }

--- a/libs/config/src/connections/redis.ts
+++ b/libs/config/src/connections/redis.ts
@@ -1,5 +1,11 @@
 import Joi from 'joi';
 import { getEnv, getEnvWithDefault } from '../helpers';
+import fs from 'fs';
+import path from 'path';
+
+const packageJson = JSON.parse(
+  fs.readFileSync(path.join(__dirname, 'package.json'), 'utf8'),
+);
 
 export interface Config {
   type: 'redis';
@@ -11,14 +17,17 @@ export interface Config {
   persist: boolean;
 }
 
-export function getConfig(): Config {
+export function getConfig(prefix = true): Config {
   return {
     type: 'redis',
     host: getEnv('REDIS_HOST', 'string')!,
     port: getEnv('REDIS_PORT', 'integer')!,
     password: getEnv('REDIS_PASSWORD', 'string'),
     db: getEnv('REDIS_DB', 'integer'),
-    keyPrefix: getEnvWithDefault('REDIS_KEY_PREFIX', 'string', 'tf2-automatic') + ':',
+    keyPrefix:
+      getEnvWithDefault('REDIS_KEY_PREFIX', 'string', 'tf2-automatic') +
+      ':' +
+      (prefix ? packageJson.name + ':' : ''),
     persist: getEnv('REDIS_PERSIST', 'boolean'),
   };
 }

--- a/libs/config/src/connections/redis.ts
+++ b/libs/config/src/connections/redis.ts
@@ -3,9 +3,17 @@ import { getEnv, getEnvWithDefault } from '../helpers';
 import fs from 'fs';
 import path from 'path';
 
-const packageJson = JSON.parse(
-  fs.readFileSync(path.join(__dirname, 'package.json'), 'utf8'),
-);
+function getAppName(): string | null {
+  if (process.env['NODE_ENV'] === 'test') {
+    return null;
+  }
+
+  const packageJson = JSON.parse(
+    fs.readFileSync(path.join(__dirname, 'package.json'), 'utf8'),
+  );
+
+  return packageJson;
+}
 
 export interface Config {
   type: 'redis';
@@ -17,7 +25,9 @@ export interface Config {
   persist: boolean;
 }
 
-export function getConfig(prefix = true): Config {
+export function getConfig(usePrefix = true): Config {
+  const prefix = getAppName();
+
   return {
     type: 'redis',
     host: getEnv('REDIS_HOST', 'string')!,
@@ -27,7 +37,7 @@ export function getConfig(prefix = true): Config {
     keyPrefix:
       getEnvWithDefault('REDIS_KEY_PREFIX', 'string', 'tf2-automatic') +
       ':' +
-      (prefix ? packageJson.name + ':' : ''),
+      (usePrefix && prefix ? prefix + ':' : ''),
     persist: getEnv('REDIS_PERSIST', 'boolean'),
   };
 }

--- a/libs/config/src/events.ts
+++ b/libs/config/src/events.ts
@@ -27,7 +27,7 @@ function getConnectionForEventsConfig() {
     case 'rabbitmq':
       return RabbitMQ.getConfig();
     case 'redis':
-      return Redis.getConfig();
+      return Redis.getConfig(false);
   }
 }
 


### PR DESCRIPTION
Redis keys were not prefixed properly

BREAKING CHANGE: Because the keys have changed all existing data in redis will no longer be used