### PR TITLE
chore: don't publish validators to npm

### DIFF
--- a/libs/is-refined-validator/project.json
+++ b/libs/is-refined-validator/project.json
@@ -38,9 +38,6 @@
         "main": "libs/is-refined-validator/src/index.ts",
         "assets": ["libs/is-refined-validator/*.md"]
       }
-    },
-    "npm": {
-      "executor": "@tf2-automatic/executors:npm"
     }
   },
   "tags": []

--- a/libs/is-steamid-validator/project.json
+++ b/libs/is-steamid-validator/project.json
@@ -38,9 +38,6 @@
         "main": "libs/is-steamid-validator/src/index.ts",
         "assets": ["libs/is-steamid-validator/*.md"]
       }
-    },
-    "npm": {
-      "executor": "@tf2-automatic/executors:npm"
     }
   },
   "tags": []


### PR DESCRIPTION
I don't remember why they were in the first place.