### PR TITLE
fix(tf2-format): fix problem with parsing spelled unusuals

### DIFF
--- a/libs/tf2-format/src/lib/parsing/econ/parser.spec.ts
+++ b/libs/tf2-format/src/lib/parsing/econ/parser.spec.ts
@@ -525,6 +525,19 @@ describe('EconParser', () => {
       expect(extracted.paintkit).toEqual('Frozen Aurora');
       expect(extracted.wear).toEqual('Minimal Wear');
     });
+
+    it('will parse spelled unusuals', () => {
+      const item = TestData.getSpelledUnusual();
+
+      const extracted = parser.extract(item);
+
+      expect(extracted.quality).toEqual('Unusual');
+      expect(extracted.effect).toEqual('Green Energy');
+      expect(extracted.spells).toEqual([
+        'Gangreen Footprints',
+        'Voices from Below',
+      ]);
+    });
   });
 
   describe('#parse', () => {

--- a/libs/tf2-format/src/lib/parsing/econ/parser.ts
+++ b/libs/tf2-format/src/lib/parsing/econ/parser.ts
@@ -45,12 +45,12 @@ const KILLSTREAK_TIERS = {
 const enum IdentifiableDescription {
   Skip = 0,
   All = 1,
-  // Paints, spells and parts have the same precedence because it has been shown
+  // Paints, spells, parts and effects have the same precedence because it has been shown
   // that they may appear in any order.
   Paint = 1,
   Spells = 1,
   Parts = 1,
-  Effect = 2,
+  Effect = 1,
   Festivized = 3,
   Killstreaker = 4,
   Sheen = 5,
@@ -688,6 +688,12 @@ export class EconParser extends Parser<
         case IdentifiableDescription.Paint:
           if (descriptions[i].value.startsWith('Paint Color: ')) {
             attributes.paint = descriptions[i].value.slice(13);
+            next = IdentifiableDescription.Effect;
+            i++;
+          }
+        case IdentifiableDescription.Effect:
+          if (descriptions[i].value.startsWith('\u2605 Unusual Effect: ')) {
+            attributes.effect = descriptions[i].value.slice(18);
             next = IdentifiableDescription.Spells;
             i++;
           }
@@ -734,12 +740,6 @@ export class EconParser extends Parser<
             i++;
             // Break again so we can check for more parts
             continue loop;
-          }
-        case IdentifiableDescription.Effect:
-          if (descriptions[i].value.startsWith('\u2605 Unusual Effect: ')) {
-            attributes.effect = descriptions[i].value.slice(18);
-            next = IdentifiableDescription.Festivized;
-            i++;
           }
         case IdentifiableDescription.Festivized:
           if (descriptions[i].value === 'Festivized') {

--- a/libs/tf2-format/src/lib/parsing/econ/test-data.ts
+++ b/libs/tf2-format/src/lib/parsing/econ/test-data.ts
@@ -3345,3 +3345,109 @@ export function getCAPPERKillstreakKit() {
     fraudwarnings: [],
   };
 }
+
+export function getSpelledUnusual() {
+  return {
+    appid: 440,
+    contextid: '2',
+    assetid: '15566903217',
+    classid: '11048121',
+    instanceid: '6855657082',
+    amount: 1,
+    pos: 5,
+    id: '15566903217',
+    currency: 0,
+    background_color: '3C352E',
+    icon_url:
+      'fWFc82js0fmoRAP-qOIPu5THSWqfSmTELLqcUywGkijVjZULUrsm1j-9xgEYYwsVVB7whzdFjsHlCOCzBOESnN97tJVUgWU7xlMuNuK2Zm42JFCXV_YLX_Zqp17qX3c0sZYzV4-3p-lVehKv6tUSNeZLcw',
+    icon_url_large:
+      'fWFc82js0fmoRAP-qOIPu5THSWqfSmTELLqcUywGkijVjZULUrsm1j-9xgEYYwsVVB7whzdFjsHlCOCzBOESnN97tJVUgWU7xlMuNuK2Zm42JFCXV_YLX_Zqp17qX3c0sZYzV4-3p-lVehKv6tUSNeZLcw',
+    descriptions: [
+      {
+        value: '★ Unusual Effect: Green Energy',
+        color: 'ffd700',
+        name: 'attribute',
+      },
+      {
+        value:
+          'Halloween: Gangreen Footprints (spell only active during event)',
+        color: '7ea9d1',
+        name: 'attribute',
+      },
+      {
+        value: 'Halloween: Voices from Below (spell only active during event)',
+        color: '7ea9d1',
+        name: 'attribute',
+      },
+      {
+        value: "Our lawyers say 'YES! YES!'",
+        name: 'attribute',
+      },
+    ],
+    tradable: true,
+    actions: [
+      {
+        link: 'http://wiki.teamfortress.com/scripts/itemredirect.php?id=378&lang=en_US',
+        name: 'Item Wiki Page...',
+      },
+      {
+        link: 'steam://rungame/440/76561202255233023/+tf_econ_item_preview%20S%owner_steamid%A%assetid%D2885264209715647610',
+        name: 'Inspect in Game...',
+      },
+    ],
+    name: 'Unusual Team Captain',
+    name_color: '8650AC',
+    type: 'Level 50 Hat',
+    market_name: 'Unusual Team Captain',
+    market_hash_name: 'Unusual Team Captain',
+    market_actions: [
+      {
+        link: 'steam://rungame/440/76561202255233023/+tf_econ_item_preview%20M%listingid%A%assetid%D2885264209715647610',
+        name: 'Inspect in Game...',
+      },
+    ],
+    commodity: false,
+    market_tradable_restriction: 7,
+    market_marketable_restriction: 0,
+    marketable: true,
+    tags: [
+      {
+        internal_name: 'rarity4',
+        name: 'Unusual',
+        category: 'Quality',
+        color: '8650AC',
+        category_name: 'Quality',
+      },
+      {
+        internal_name: 'misc',
+        name: 'Cosmetic',
+        category: 'Type',
+        color: '',
+        category_name: 'Type',
+      },
+      {
+        internal_name: 'Soldier',
+        name: 'Soldier',
+        category: 'Class',
+        color: '',
+        category_name: 'Class',
+      },
+      {
+        internal_name: 'Medic',
+        name: 'Medic',
+        category: 'Class',
+        color: '',
+        category_name: 'Class',
+      },
+      {
+        internal_name: 'Heavy',
+        name: 'Heavy',
+        category: 'Class',
+        color: '',
+        category_name: 'Class',
+      },
+    ],
+    is_currency: false,
+    fraudwarnings: [],
+  };
+}


### PR DESCRIPTION
Spells on unusuals were ignored when the item was a cosmetic

Fix #616