### PR TITLE
fix(tf2-format): handle edge case with applied war paints on strange items

### DIFF
--- a/libs/tf2-format/src/lib/parsing/econ/parser.spec.ts
+++ b/libs/tf2-format/src/lib/parsing/econ/parser.spec.ts
@@ -548,6 +548,17 @@ describe('EconParser', () => {
       expect(extracted.wear).toEqual('Factory New');
       expect(extracted.paintkit).toEqual('Red Rock Roscoe');
     });
+
+    it('will parse strange applied war paints', () => {
+      const item = TestData.getStrangeAppliedWarpaint();
+
+      const extracted = parser.extract(item);
+
+      expect(extracted.quality).toEqual('Strange');
+      expect(extracted.wear).toEqual('Field-Tested');
+      expect(extracted.paintkit).toEqual('Kiln and Conquer');
+      expect(extracted.elevated).toEqual(false);
+    });
   });
 
   describe('#parse', () => {

--- a/libs/tf2-format/src/lib/parsing/econ/parser.ts
+++ b/libs/tf2-format/src/lib/parsing/econ/parser.ts
@@ -187,7 +187,9 @@ export class EconParser extends Parser<
       const isWarPaint = tags.Type === 'War Paint';
       // Set the quality of the item based on certain conditions to better match
       // how the TF2 GC stores the quality of items with a paint kit.
-      if (raw.effect !== null && !isWarPaint) {
+      if (!isWarPaint && descriptions.statclock) {
+        raw.quality = 'Strange';
+      } else if (raw.effect !== null && !isWarPaint) {
         // The quality of unusual war paints is still "Unusual", hence the check
         // for the type.
         raw.quality = 'Decorated Weapon';
@@ -658,13 +660,24 @@ export class EconParser extends Parser<
 
     // I don't like that this is outside the switch statement but it is the most
     // efficient way to do it.
-    if (tags.Rarity !== undefined) {
+    if (tags.Exterior !== undefined) {
       if (
-        tags.Exterior !== undefined &&
+        tags.Rarity !== undefined &&
         descriptions[i].value.startsWith(tags.Rarity + ' Grade ') &&
         descriptions[i].value.endsWith(' (' + tags.Exterior + ')')
       ) {
         attributes.grade = descriptions[i].value;
+        i++;
+      } else if (
+        tags.Rarity === undefined &&
+        descriptions[i].value.endsWith('(' + tags.Exterior + ')')
+      ) {
+        // This is dumb but sometimes an item does not have a rarity in the tags
+        // but it does in the description...
+        attributes.grade = descriptions[i].value.slice(
+          0,
+          descriptions[i].value.indexOf(' Grade'),
+        );
         i++;
       }
 

--- a/libs/tf2-format/src/lib/parsing/econ/test-data.ts
+++ b/libs/tf2-format/src/lib/parsing/econ/test-data.ts
@@ -3663,3 +3663,283 @@ export function getRedRockRoscoePistol() {
     fraudwarnings: [],
   };
 }
+
+export function getStrangeAppliedWarpaint() {
+  return {
+    appid: 440,
+    contextid: '2',
+    assetid: '15567713416',
+    classid: '6875155395',
+    instanceid: '6961165889',
+    amount: 1,
+    pos: 108,
+    id: '15567713416',
+    currency: 0,
+    background_color: '3C352E',
+    icon_url:
+      'fWFc82js0fmoRAP-qOIPu5THSWqfSmTELLqcUywGkijVjZULUrsm1j-9xgEMaQkUTxr2vTx8mMnvA-aHAfQ_ktk664MayTdinxVwPffnaWFYexDHDPIPCcot8Qn-Wmkz7pNhV9PjoLpeeAS6soPPN-YoZo4fGJGFD_PSZAv5408-0qlZJ5favmqximVL15ub',
+    icon_url_large:
+      'fWFc82js0fmoRAP-qOIPu5THSWqfSmTELLqcUywGkijVjZULUrsm1j-9xgEMaQkUTxr2vTx8mMnvA-aHAfQ_ktk664MayTdinxVwPffnaWFYexDHDPIPCcot8Qn-Wmkz7pNhV9PjoLpeeAS6soPPN-YoZo4fGJGFD_PSZAv5408-0qlZJ5favmqximVL15ub',
+    descriptions: [
+      {
+        value: 'Mercenary Grade Flame Thrower (Field-Tested)',
+        color: '4b69ff',
+        name: 'attribute',
+      },
+      {
+        value: 'Strange Stat Clock Attached',
+        color: 'CF6A32',
+        name: 'attribute',
+      },
+      {
+        value: '     Kills: 4063',
+        color: '756b5e',
+        name: 'attribute',
+      },
+      {
+        value: '     Cloaked Spies Killed: 91',
+        color: '756b5e',
+        name: 'attribute',
+      },
+      {
+        value: '     Projectiles Reflected: 1007',
+        color: '756b5e',
+        name: 'attribute',
+      },
+      {
+        value: '     Teammates Extinguished: 319',
+        color: '756b5e',
+        name: 'attribute',
+      },
+      {
+        value: '★ Unusual Effect: Hot',
+        color: 'ffd700',
+        name: 'attribute',
+      },
+      {
+        value: 'This weapon holsters 30% faster',
+        color: '7ea9d1',
+        name: 'attribute',
+      },
+      {
+        value: 'This weapon deploys 60% faster',
+        color: '7ea9d1',
+        name: 'attribute',
+      },
+      {
+        value: 'Extinguishing teammates restores 20 health',
+        color: '7ea9d1',
+        name: 'attribute',
+      },
+      {
+        value: 'Killstreaker: Singularity',
+        color: '7ea9d1',
+        name: 'attribute',
+      },
+      {
+        value: 'Sheen: Manndarin',
+        color: '7ea9d1',
+        name: 'attribute',
+      },
+      {
+        value: 'Killstreaks Active',
+        color: '7ea9d1',
+        name: 'attribute',
+      },
+      {
+        value: '-66% afterburn damage penalty',
+        color: 'd83636',
+        name: 'attribute',
+      },
+      {
+        value: '+25% airblast cost',
+        color: 'd83636',
+        name: 'attribute',
+      },
+      {
+        type: 'usertext',
+        value: "''If you are reading this, that airblast was 100% calculated''",
+        name: 'attribute',
+      },
+      {
+        value: ' ',
+        name: 'attribute',
+      },
+      {
+        value: "The Gas Jockey's Gear",
+        color: 'e1e10f',
+        name: 'attribute',
+      },
+      {
+        value: ' ',
+        name: 'attribute',
+      },
+      {
+        value: 'The Degreaser',
+        color: '8b8989',
+        name: 'attribute',
+      },
+      {
+        value: 'The Powerjack',
+        color: '8b8989',
+        name: 'attribute',
+      },
+      {
+        value: 'The Attendant',
+        color: '8b8989',
+        name: 'attribute',
+      },
+      {
+        value: ' ',
+        name: 'attribute',
+      },
+      {
+        value: 'Item Set Bonus:',
+        color: 'e1e10f',
+        name: 'attribute',
+      },
+      {
+        value: 'Leave a Calling Card on your victims',
+        color: '8b8989',
+        name: 'attribute',
+      },
+      {
+        value: ' ',
+        name: 'attribute',
+      },
+      {
+        value: ' ',
+        name: 'attribute',
+      },
+      {
+        value: 'Scream Fortress XIII Collection',
+        name: 'attribute',
+      },
+      {
+        value: '    Misfortunate War Paint',
+        color: 'eb4b4b',
+        name: 'attribute',
+      },
+      {
+        value: '    Party Phantoms War Paint',
+        color: 'd32ce6',
+        name: 'attribute',
+      },
+      {
+        value: '    Broken Bones War Paint',
+        color: 'd32ce6',
+        name: 'attribute',
+      },
+      {
+        value: '    Swashbuckled War Paint',
+        color: '8847ff',
+        name: 'attribute',
+      },
+      {
+        value: '    Neon-ween War Paint',
+        color: '8847ff',
+        name: 'attribute',
+      },
+      {
+        value: '    Polter-Guised War Paint',
+        color: '8847ff',
+        name: 'attribute',
+      },
+      {
+        value: '    Necromanced War Paint',
+        color: '8847ff',
+        name: 'attribute',
+      },
+      {
+        value: '    Skull Cracked War Paint',
+        color: '4b69ff',
+        name: 'attribute',
+      },
+      {
+        value: '    Simple Spirits War Paint',
+        color: '4b69ff',
+        name: 'attribute',
+      },
+      {
+        value: '    Potent Poison War Paint',
+        color: '4b69ff',
+        name: 'attribute',
+      },
+      {
+        value: '    Searing Souls War Paint',
+        color: '4b69ff',
+        name: 'attribute',
+      },
+      {
+        value: '★ Kiln and Conquer War Paint',
+        color: '4b69ff',
+        name: 'attribute',
+      },
+      {
+        value: '    Sarsaparilla Sprayed War Paint',
+        color: '4b69ff',
+        name: 'attribute',
+      },
+    ],
+    tradable: true,
+    actions: [
+      {
+        link: 'http://wiki.teamfortress.com/scripts/itemredirect.php?id=215&lang=en_US',
+        name: 'Item Wiki Page...',
+      },
+      {
+        link: 'steam://rungame/440/76561202255233023/+tf_econ_item_preview%20S%owner_steamid%A%assetid%D10155133839288036721',
+        name: 'Inspect in Game...',
+      },
+    ],
+    fraudwarnings: ['This item has been renamed.\nOriginal name: "Degreaser"'],
+    name: "''A Moment of Self Reflection''",
+    name_color: '8650AC',
+    type: '',
+    market_name:
+      'Strange Unusual Professional Killstreak Kiln and Conquer Degreaser (Field-Tested)',
+    market_hash_name:
+      'Strange Unusual Professional Killstreak Kiln and Conquer Degreaser (Field-Tested)',
+    market_actions: [
+      {
+        link: 'steam://rungame/440/76561202255233023/+tf_econ_item_preview%20M%listingid%A%assetid%D10155133839288036721',
+        name: 'Inspect in Game...',
+      },
+    ],
+    commodity: false,
+    market_tradable_restriction: 7,
+    market_marketable_restriction: 0,
+    marketable: true,
+    tags: [
+      {
+        internal_name: 'rarity4',
+        name: 'Unusual',
+        category: 'Quality',
+        color: '8650AC',
+        category_name: 'Quality',
+      },
+      {
+        internal_name: 'primary',
+        name: 'Primary weapon',
+        category: 'Type',
+        color: '',
+        category_name: 'Type',
+      },
+      {
+        internal_name: 'Pyro',
+        name: 'Pyro',
+        category: 'Class',
+        color: '',
+        category_name: 'Class',
+      },
+      {
+        internal_name: 'TFUI_InvTooltip_FieldTested',
+        name: 'Field-Tested',
+        category: 'Exterior',
+        color: '',
+        category_name: 'Exterior',
+      },
+    ],
+    is_currency: false,
+  };
+}


### PR DESCRIPTION
The item does not have a rarity tag so it is not detecting the statclock. Also added a check to force the item to be Strange.

Fix #619