### PR TITLE
fix(tf2-format): handle edge case with generating name of items with attribute 0

### DIFF
--- a/libs/tf2-format/src/lib/naming/index.ts
+++ b/libs/tf2-format/src/lib/naming/index.ts
@@ -49,7 +49,7 @@ export class NameGenerator {
       (item.quality === 6 && item.elevated === true) ||
       (item.quality !== 6 && item.quality !== 15 && item.quality !== 5) ||
       (item.quality === 5 && !item.effect) ||
-      schemaItem.item_quality == 5
+      schemaItem.item_quality === 5
     ) {
       let quality = this.schema.getQualityById(item.quality);
       if (quality === undefined) {
@@ -61,7 +61,7 @@ export class NameGenerator {
       name += quality + ' ';
     }
 
-    if (item.effect) {
+    if (typeof item.effect === 'number') {
       let effect = this.schema.getEffectById(item.effect);
       if (effect === undefined) {
         effect = await this.schema.fetchEffectById(item.effect);
@@ -80,7 +80,7 @@ export class NameGenerator {
       name += KILLSTREAKS[item.killstreak - 1] + ' ';
     }
 
-    if (item.target) {
+    if (typeof item.target === 'number') {
       let target = this.schema.getItemByDefindex(item.target);
       if (target === undefined) {
         target = await this.schema.fetchItemByDefindex(item.target);
@@ -91,7 +91,7 @@ export class NameGenerator {
       name += target.item_name + ' ';
     }
 
-    if (item.outputQuality && item.outputQuality !== 6) {
+    if (typeof item.outputQuality === 'number' && item.outputQuality !== 6) {
       let quality = this.schema.getQualityById(item.outputQuality);
       if (quality === undefined) {
         quality = await this.schema.fetchQualityById(item.outputQuality);
@@ -102,7 +102,7 @@ export class NameGenerator {
       name += quality + ' ';
     }
 
-    if (item.output) {
+    if (typeof item.output === 'number') {
       let output = this.schema.getItemByDefindex(item.output);
       if (output === undefined) {
         output = await this.schema.fetchItemByDefindex(item.output);
@@ -117,7 +117,7 @@ export class NameGenerator {
       name += 'Australium ';
     }
 
-    if (item.paintkit) {
+    if (typeof item.paintkit === 'number') {
       let paintkit = this.schema.getPaintkitById(item.paintkit);
       if (paintkit === undefined) {
         paintkit = await this.schema.fetchPaintkitById(item.paintkit);
@@ -138,7 +138,7 @@ export class NameGenerator {
       name += ' (' + WEAR[item.wear - 1] + ')';
     }
 
-    if (item.crateSeries) {
+    if (typeof item.crateSeries === 'number') {
       name += ' #' + item.crateSeries;
     }
 

--- a/libs/tf2-format/src/lib/naming/naming.spec.ts
+++ b/libs/tf2-format/src/lib/naming/naming.spec.ts
@@ -195,5 +195,39 @@ describe('NameGenerator', () => {
 
       expect(name).toBe('Strange Circling Heart Hong Kong Cone');
     });
+
+    it('will create the name of a normal quality item', async () => {
+      schema.getItemByDefindex.mockReturnValueOnce({
+        item_name: 'Minigun',
+        proper_name: false,
+        item_quality: 0,
+      });
+      schema.getQualityById.mockReturnValueOnce('Normal');
+
+      const name = await generator.getName({
+        defindex: 202,
+        quality: 0,
+      });
+
+      expect(name).toBe('Normal Minigun');
+    });
+
+    it('will create the name of a Red Rock Roscoe Pistol', async () => {
+      schema.getItemByDefindex.mockReturnValueOnce({
+        item_name: 'Pistol',
+        proper_name: true,
+        item_quality: 15,
+      });
+      schema.getPaintkitById.mockReturnValueOnce('Red Rock Roscoe');
+
+      const name = await generator.getName({
+        defindex: 15013,
+        quality: 15,
+        wear: 1,
+        paintkit: 0,
+      });
+
+      expect(name).toBe('Red Rock Roscoe Pistol (Factory New)');
+    });
   });
 });


### PR DESCRIPTION
For example, the "Red Rock Roscoe" paintkit has id 0.

Fix #620