### PR TITLE
ci: only write to pnpm cache in affected jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,7 +72,7 @@ jobs:
         shell: bash
         run: |
           echo "STORE_PATH=$(pnpm store path --silent)" >> $GITHUB_ENV
-      - uses: actions/cache@v4
+      - uses: actions/cache/restore@v4
         name: Setup pnpm cache
         with:
           path: ${{ env.STORE_PATH }}
@@ -111,7 +111,7 @@ jobs:
         shell: bash
         run: |
           echo "STORE_PATH=$(pnpm store path --silent)" >> $GITHUB_ENV
-      - uses: actions/cache@v4
+      - uses: actions/cache/restore@v4
         name: Setup pnpm cache
         with:
           path: ${{ env.STORE_PATH }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -65,7 +65,7 @@ jobs:
         shell: bash
         run: |
           echo "STORE_PATH=$(pnpm store path --silent)" >> $GITHUB_ENV
-      - uses: actions/cache@v4
+      - uses: actions/cache/restore@v4
         name: Setup pnpm cache
         with:
           path: ${{ env.STORE_PATH }}
@@ -141,7 +141,7 @@ jobs:
         shell: bash
         run: |
           echo "STORE_PATH=$(pnpm store path --silent)" >> $GITHUB_ENV
-      - uses: actions/cache@v4
+      - uses: actions/cache/restore@v4
         name: Setup pnpm cache
         with:
           path: ${{ env.STORE_PATH }}
@@ -183,7 +183,7 @@ jobs:
         shell: bash
         run: |
           echo "STORE_PATH=$(pnpm store path --silent)" >> $GITHUB_ENV
-      - uses: actions/cache@v4
+      - uses: actions/cache/restore@v4
         name: Setup pnpm cache
         with:
           path: ${{ env.STORE_PATH }}


### PR DESCRIPTION
It is a waste of time to write the same data multiple times.