### PR TITLE
ci: skip publish jobs if there is nothing to publish

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,7 +48,7 @@ jobs:
   release:
     runs-on: ubuntu-latest
     needs: [affected]
-    if: ${{ fromJson(needs.affected.outputs.docker)[0] || fromJson(needs.affected.outputs.npm)[0] }}
+    if: needs.affected.outputs.docker != '[]' || needs.affected.outputs.npm != '[]'
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -91,7 +91,7 @@ jobs:
   publish_to_docker:
     runs-on: ubuntu-latest
     needs: [affected, release]
-    if: needs.release.outputs.new_release_published == 'true'
+    if: needs.release.outputs.new_release_published == 'true' && needs.affected.outputs.docker != '[]'
     strategy:
       fail-fast: false
       matrix:
@@ -161,7 +161,7 @@ jobs:
   publish_to_npm:
     runs-on: ubuntu-latest
     needs: [affected, release]
-    if: needs.release.outputs.new_release_published == 'true'
+    if: needs.release.outputs.new_release_published == 'true' && needs.affected.outputs.npm != '[]'
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
This should fix the "failure" GitHub makes even though everything passes.