### PR TITLE
fix(tf2-format): check if attribute is a number before adding it to the sku

### DIFF
--- a/libs/tf2-format/src/lib/sku/sku.spec.ts
+++ b/libs/tf2-format/src/lib/sku/sku.spec.ts
@@ -35,6 +35,13 @@ describe('SKU', () => {
 
       expect(sku).toEqual('378;5;u13;p16738740');
     });
+
+    it('will generate red rock roscoe pistol', () => {
+      const item = TestData.getRedRockRoscoePistolItem();
+
+      const sku = SKU.fromObject(item);
+      expect(sku).toEqual('15013;15;w1;pk0');
+    })
   });
 
   describe('#fromString', () => {

--- a/libs/tf2-format/src/lib/sku/sku.ts
+++ b/libs/tf2-format/src/lib/sku/sku.ts
@@ -22,7 +22,7 @@ export class SKU {
     if (item.wear) {
       sku += `;w${item.wear}`;
     }
-    if (item.paintkit) {
+    if (item.paintkit !== null) {
       sku += `;pk${item.paintkit}`;
     }
     if (item.elevated === true) {

--- a/libs/tf2-format/src/lib/sku/sku.ts
+++ b/libs/tf2-format/src/lib/sku/sku.ts
@@ -4,7 +4,7 @@ export class SKU {
   static fromObject(item: RequiredItemAttributes): string {
     let sku = `${item.defindex};${item.quality}`;
 
-    if (item.effect) {
+    if (typeof item.effect === 'number') {
       sku += `;u${item.effect}`;
     }
     if (item.australium === true) {
@@ -28,28 +28,28 @@ export class SKU {
     if (item.elevated === true) {
       sku += ';strange';
     }
-    if (item.killstreak !== undefined && item.killstreak !== 0) {
+    if (typeof item.killstreak === 'number' && item.killstreak !== 0) {
       sku += `;kt-${item.killstreak}`;
     }
-    if (item.sheen) {
+    if (typeof item.sheen === 'number') {
       sku += `;ks-${item.sheen}`;
     }
-    if (item.killstreaker) {
+    if (typeof item.killstreaker === 'number') {
       sku += `;ke-${item.killstreaker}`;
     }
-    if (item.target) {
+    if (typeof item.target === 'number') {
       sku += `;td-${item.target}`;
     }
     if (item.festivized === true) {
       sku += ';festive';
     }
-    if (item.crateSeries) {
+    if (typeof item.crateSeries === 'number') {
       sku += `;c${item.crateSeries}`;
     }
-    if (item.output) {
+    if (typeof item.output === 'number') {
       sku += `;od-${item.output}`;
     }
-    if (item.outputQuality) {
+    if (typeof item.outputQuality === 'number') {
       sku += `;oq-${item.outputQuality}`;
     }
 

--- a/libs/tf2-format/src/lib/sku/sku.ts
+++ b/libs/tf2-format/src/lib/sku/sku.ts
@@ -22,7 +22,7 @@ export class SKU {
     if (item.wear) {
       sku += `;w${item.wear}`;
     }
-    if (item.paintkit !== null) {
+    if (typeof item.paintkit === 'number') {
       sku += `;pk${item.paintkit}`;
     }
     if (item.elevated === true) {

--- a/libs/tf2-format/src/lib/sku/test-data.ts
+++ b/libs/tf2-format/src/lib/sku/test-data.ts
@@ -35,6 +35,15 @@ export function getPaintedUnusualItem(): RequiredItemAttributes {
   };
 }
 
+export function getRedRockRoscoePistolItem(): RequiredItemAttributes {
+  return {
+    defindex: 15013,
+    quality: 15,
+    wear: 1,
+    paintkit: 0
+  }
+}
+
 export function getBasicSKU(): string {
   return '5021;6';
 }


### PR DESCRIPTION
The item-to-SKU parser will read a paintkit ID of 0 as a falsey value, resulting in Red Rock Roscoe skins not having a paintkit in their SKU.