### PR TITLE
feat(escrow): support querying escrow duration by offerId

### DIFF
--- a/apps/bot-manager/src/escrow/escrow.processor.ts
+++ b/apps/bot-manager/src/escrow/escrow.processor.ts
@@ -53,8 +53,6 @@ export class EscrowProcessor extends CustomWorkerHost<EscrowJobData> {
         error: err.response,
         result: null,
         bot: this.cls.get('bot'),
-        token: job.data.options.token,
-        offerId: job.data.options.offerId,
         ttl: job.data.options.ttl,
       },
     );
@@ -81,8 +79,6 @@ export class EscrowProcessor extends CustomWorkerHost<EscrowJobData> {
         error: null,
         result,
         bot: this.cls.get('bot'),
-        token: job.data.options.token,
-        offerId: job.data.options.offerId,
         ttl: job.data.options.ttl,
       },
     );

--- a/apps/bot-manager/src/escrow/escrow.processor.ts
+++ b/apps/bot-manager/src/escrow/escrow.processor.ts
@@ -54,6 +54,7 @@ export class EscrowProcessor extends CustomWorkerHost<EscrowJobData> {
         result: null,
         bot: this.cls.get('bot'),
         token: job.data.options.token,
+        offerId: job.data.options.offerId,
         ttl: job.data.options.ttl,
       },
     );
@@ -70,6 +71,7 @@ export class EscrowProcessor extends CustomWorkerHost<EscrowJobData> {
       bot,
       new SteamID(job.data.options.steamid64),
       job.data.options.token,
+      job.data.options.offerId,
     );
 
     await this.escrowService.saveEscrow(
@@ -80,6 +82,7 @@ export class EscrowProcessor extends CustomWorkerHost<EscrowJobData> {
         result,
         bot: this.cls.get('bot'),
         token: job.data.options.token,
+        offerId: job.data.options.offerId,
         ttl: job.data.options.ttl,
       },
     );

--- a/apps/bot-manager/src/escrow/escrow.service.ts
+++ b/apps/bot-manager/src/escrow/escrow.service.ts
@@ -191,8 +191,6 @@ export class EscrowService implements OnModuleDestroy {
     const save: EscrowData = {
       timestamp: result.timestamp,
       bot: result.bot,
-      token: result.token,
-      offerId: result.offerId,
     };
 
     if (result.result) {

--- a/apps/bot-manager/src/escrow/escrow.service.ts
+++ b/apps/bot-manager/src/escrow/escrow.service.ts
@@ -81,6 +81,7 @@ export class EscrowService implements OnModuleDestroy {
       {
         steamid64: steamid.getSteamID64(),
         token: dto.token,
+        offerId: dto.offerId,
         ttl: dto.ttl,
       },
       options,
@@ -96,8 +97,10 @@ export class EscrowService implements OnModuleDestroy {
     query: GetEscrowDto,
   ): Promise<EscrowResponse> {
     assert(
-      query.token !== undefined || query.bot !== undefined,
-      'Either token or bot must be provided',
+      query.token !== undefined ||
+        query.bot !== undefined ||
+        query.offerId !== undefined,
+      'Either token, bot, or offerId must be provided',
     );
 
     try {
@@ -120,6 +123,7 @@ export class EscrowService implements OnModuleDestroy {
     bot: Bot,
     steamid: SteamID,
     token?: string,
+    offerId?: string,
   ): Promise<GetEscrowResponse> {
     const response = await firstValueFrom(
       this.httpService.get<GetEscrowResponse>(
@@ -130,6 +134,7 @@ export class EscrowService implements OnModuleDestroy {
         {
           params: {
             token,
+            offerId,
           },
         },
       ),
@@ -157,7 +162,8 @@ export class EscrowService implements OnModuleDestroy {
     if (
       dto &&
       ((dto.bot && dto.bot.getSteamID64() !== object.bot.toString()) ||
-        (dto.token && dto.token !== object.token?.toString()))
+        (dto.token && dto.token !== object.token?.toString()) ||
+        (dto.offerId && dto.offerId !== object.offerId?.toString()))
     ) {
       throw new NotFoundException('Escrow not found');
     }
@@ -186,6 +192,7 @@ export class EscrowService implements OnModuleDestroy {
       timestamp: result.timestamp,
       bot: result.bot,
       token: result.token,
+      offerId: result.offerId,
     };
 
     if (result.result) {

--- a/apps/bot-manager/src/escrow/escrow.service.ts
+++ b/apps/bot-manager/src/escrow/escrow.service.ts
@@ -96,15 +96,8 @@ export class EscrowService implements OnModuleDestroy {
     steamid: SteamID,
     query: GetEscrowDto,
   ): Promise<EscrowResponse> {
-    assert(
-      query.token !== undefined ||
-        query.bot !== undefined ||
-        query.offerId !== undefined,
-      'Either token, bot, or offerId must be provided',
-    );
-
     try {
-      const cached = await this.getEscrowFromCache(steamid, query);
+      const cached = await this.getEscrowFromCache(steamid);
       return cached;
     } catch (err) {
       if (!(err instanceof NotFoundException)) {
@@ -143,10 +136,7 @@ export class EscrowService implements OnModuleDestroy {
     return response.data;
   }
 
-  async getEscrowFromCache(
-    steamid: SteamID,
-    dto?: GetEscrowDto,
-  ): Promise<EscrowResponse> {
+  async getEscrowFromCache(steamid: SteamID): Promise<EscrowResponse> {
     const key = this.getKey(steamid);
 
     const [ttl, object] = await Promise.all([
@@ -155,16 +145,6 @@ export class EscrowService implements OnModuleDestroy {
     ]);
 
     if (ttl === -2 || object === null) {
-      throw new NotFoundException('Escrow not found');
-    }
-
-    // Check if the dto matches the cached data and throw an error if it doesn't
-    if (
-      dto &&
-      ((dto.bot && dto.bot.getSteamID64() !== object.bot.toString()) ||
-        (dto.token && dto.token !== object.token?.toString()) ||
-        (dto.offerId && dto.offerId !== object.offerId?.toString()))
-    ) {
       throw new NotFoundException('Escrow not found');
     }
 

--- a/apps/bot-manager/src/escrow/escrow.types.ts
+++ b/apps/bot-manager/src/escrow/escrow.types.ts
@@ -26,8 +26,6 @@ export interface EscrowResultData {
 export type EscrowResult = (EscrowErrorData | EscrowResultData) & {
   timestamp: number;
   bot: string;
-  token?: string;
-  offerId?: string;
   ttl?: number;
 };
 
@@ -36,6 +34,4 @@ export interface EscrowData {
   error?: Buffer;
   result?: Buffer;
   bot: string;
-  token?: string;
-  offerId?: string;
 }

--- a/apps/bot-manager/src/escrow/escrow.types.ts
+++ b/apps/bot-manager/src/escrow/escrow.types.ts
@@ -5,6 +5,7 @@ export type EscrowJobData = JobData<
   {
     steamid64: string;
     token?: string;
+    offerId?: string;
     ttl?: number;
   },
   {
@@ -26,6 +27,7 @@ export type EscrowResult = (EscrowErrorData | EscrowResultData) & {
   timestamp: number;
   bot: string;
   token?: string;
+  offerId?: string;
   ttl?: number;
 };
 
@@ -35,4 +37,5 @@ export interface EscrowData {
   result?: Buffer;
   bot: string;
   token?: string;
+  offerId?: string;
 }

--- a/apps/bot/src/escrow/escrow.controller.ts
+++ b/apps/bot/src/escrow/escrow.controller.ts
@@ -28,17 +28,25 @@ export class EscrowController {
     example: '_Eq1Y3An',
     required: false,
   })
-  getEscrowDuration(
+  @ApiQuery({
+    name: 'offerId',
+    description: 'The ID of an existing trade offer',
+    required: false,
+  })
+  async getEscrowDuration(
     @Param('steamid', ParseSteamIDPipe) steamid: SteamID,
     @Query('token')
     token?: string,
+    @Query('offerId')
+    offerId?: string,
   ): Promise<GetEscrowResponse> {
-    return this.escrowService
-      .getEscrowDuration(steamid, token)
-      .then((escrowDays) => {
-        return {
-          escrowDays,
-        };
-      });
+    const escrowDays = await this.escrowService.getEscrowDuration(
+      steamid,
+      token,
+      offerId,
+    );
+    return {
+      escrowDays,
+    };
   }
 }

--- a/apps/bot/src/escrow/escrow.module.ts
+++ b/apps/bot/src/escrow/escrow.module.ts
@@ -3,9 +3,10 @@ import { EscrowService } from './escrow.service';
 import { EscrowController } from './escrow.controller';
 import { BotModule } from '../bot/bot.module';
 import { FriendsModule } from '../friends/friends.module';
+import { TradesModule } from '../trades/trades.module';
 
 @Module({
-  imports: [BotModule, FriendsModule],
+  imports: [BotModule, FriendsModule, TradesModule],
   providers: [EscrowService],
   controllers: [EscrowController],
 })

--- a/apps/bot/src/escrow/escrow.service.ts
+++ b/apps/bot/src/escrow/escrow.service.ts
@@ -16,7 +16,16 @@ export class EscrowService {
 
   private async getOffer(steamid: SteamID, token?: string, offerId?: string) {
     if (offerId) {
-      return this.tradesService.getActualOffer(offerId);
+      const offer = await this.tradesService.getActualOffer(offerId);
+      if (offer.isOurOffer) {
+        throw new BadRequestException('Offer was made by us');
+      }
+
+      if (offer.partner.getSteamID64() !== steamid.getSteamID64()) {
+        throw new BadRequestException(
+          'Partner steamid does not match provided steamid',
+        );
+      }
     }
 
     if (!token) {

--- a/apps/bot/src/escrow/escrow.service.ts
+++ b/apps/bot/src/escrow/escrow.service.ts
@@ -1,12 +1,8 @@
-import {
-  BadRequestException,
-  Injectable,
-  UnauthorizedException,
-} from '@nestjs/common';
+import { BadRequestException, Injectable } from '@nestjs/common';
 import { BotService } from '../bot/bot.service';
 import SteamID from 'steamid';
 import { FriendsService } from '../friends/friends.service';
-import TradeOffer from 'steam-tradeoffer-manager/lib/classes/TradeOffer';
+import { TradesService } from '../trades/trades.service';
 
 @Injectable()
 export class EscrowService {
@@ -15,68 +11,35 @@ export class EscrowService {
   constructor(
     private readonly botService: BotService,
     private readonly friendsService: FriendsService,
+    private readonly tradesService: TradesService,
   ) {}
+
+  private async getOffer(steamid: SteamID, token?: string, offerId?: string) {
+    if (offerId) {
+      return this.tradesService.getActualOffer(offerId);
+    }
+
+    if (!token) {
+      const isFriend = await this.friendsService.isFriend(steamid);
+      if (!isFriend) {
+        throw new BadRequestException(
+          'Token is required when not friends with the user',
+        );
+      }
+    }
+
+    return this.manager.createOffer(steamid, token);
+  }
 
   async getEscrowDuration(
     steamid: SteamID,
     token?: string,
     offerId?: string,
   ): Promise<number> {
-    let offer: TradeOffer;
-    if (offerId) {
-      offer = await new Promise<TradeOffer>((resolve, reject) => {
-        this.manager.getOffer(offerId, (err, trade) =>
-          err ? reject(err) : resolve(trade),
-        );
-      });
-    } else {
-      if (!token) {
-        const isFriend = await this.friendsService.isFriend(steamid);
+    const offer = await this.getOffer(steamid, token, offerId);
 
-        if (!isFriend) {
-          throw new BadRequestException(
-            'Token is required when not friends with the user',
-          );
-        }
-      }
-
-      offer = this.manager.createOffer(steamid, token);
-    }
-    const details = await this.getUserDetails(offer);
+    const details = await this.tradesService.getUserDetails(offer);
 
     return Math.max(details.me.escrowDays, details.them.escrowDays);
-  }
-
-  private getUserDetails(offer: TradeOffer): Promise<{
-    me: TradeOffer.UserDetails;
-    them: TradeOffer.UserDetails;
-  }> {
-    return new Promise((resolve, reject) => {
-      offer.getUserDetails((err, me, them) => {
-        if (err) {
-          if (
-            err.message.endsWith(
-              `'s inventory privacy is set to "Private".  They are unable to receive trade offers.`,
-            )
-          ) {
-            return reject(new UnauthorizedException('Inventory is private'));
-          } else if (err.message.endsWith(' because they have a trade ban.')) {
-            return reject(new BadRequestException('User is trade banned'));
-          } else if (
-            err.message.startsWith(
-              'This Trade URL is no longer valid for sending a trade offer to ',
-            )
-          ) {
-            return reject(
-              new BadRequestException('Trade offer token is invalid'),
-            );
-          }
-
-          return reject(err);
-        }
-
-        resolve({ me, them });
-      });
-    });
   }
 }

--- a/apps/bot/src/escrow/escrow.service.ts
+++ b/apps/bot/src/escrow/escrow.service.ts
@@ -17,18 +17,31 @@ export class EscrowService {
     private readonly friendsService: FriendsService,
   ) {}
 
-  async getEscrowDuration(steamid: SteamID, token?: string): Promise<number> {
-    if (!token) {
-      const isFriend = await this.friendsService.isFriend(steamid);
-
-      if (!isFriend) {
-        throw new BadRequestException(
-          'Token is required when not friends with the user',
+  async getEscrowDuration(
+    steamid: SteamID,
+    token?: string,
+    offerId?: string,
+  ): Promise<number> {
+    let offer: TradeOffer;
+    if (offerId) {
+      offer = await new Promise<TradeOffer>((resolve, reject) => {
+        this.manager.getOffer(offerId, (err, trade) =>
+          err ? reject(err) : resolve(trade),
         );
-      }
-    }
+      });
+    } else {
+      if (!token) {
+        const isFriend = await this.friendsService.isFriend(steamid);
 
-    const offer = this.manager.createOffer(steamid, token);
+        if (!isFriend) {
+          throw new BadRequestException(
+            'Token is required when not friends with the user',
+          );
+        }
+      }
+
+      offer = this.manager.createOffer(steamid, token);
+    }
     const details = await this.getUserDetails(offer);
 
     return Math.max(details.me.escrowDays, details.them.escrowDays);

--- a/apps/bot/src/trades/trades.module.ts
+++ b/apps/bot/src/trades/trades.module.ts
@@ -37,5 +37,6 @@ import { GarbageCollectorService } from './gc.service';
       labelNames: ['type'],
     }),
   ],
+  exports: [TradesService],
 })
 export class TradesModule {}

--- a/apps/bot/src/trades/trades.service.ts
+++ b/apps/bot/src/trades/trades.service.ts
@@ -2,6 +2,7 @@ import {
   BadRequestException,
   Injectable,
   NotFoundException,
+  UnauthorizedException,
 } from '@nestjs/common';
 import { BotService } from '../bot/bot.service';
 import SteamTradeOfferManager from 'steam-tradeoffer-manager';
@@ -670,6 +671,13 @@ export class TradesService {
     return this.loadOffer(id);
   }
 
+  async getActualOffer(
+    id: string,
+    useCache?: boolean,
+  ): Promise<ActualTradeOffer> {
+    return this.loadOfferWithCaching(id, useCache);
+  }
+
   async getOffer(id: string, useCache?: boolean): Promise<GetTradeResponse> {
     const offer = await this.loadOfferWithCaching(id, useCache);
     return this.mapOffer(offer);
@@ -1083,6 +1091,39 @@ export class TradesService {
           });
         },
       );
+    });
+  }
+
+  public getUserDetails(offer: ActualTradeOffer): Promise<{
+    me: ActualTradeOffer.UserDetails;
+    them: ActualTradeOffer.UserDetails;
+  }> {
+    return new Promise((resolve, reject) => {
+      offer.getUserDetails((err, me, them) => {
+        if (err) {
+          if (
+            err.message.endsWith(
+              `'s inventory privacy is set to "Private".  They are unable to receive trade offers.`,
+            )
+          ) {
+            return reject(new UnauthorizedException('Inventory is private'));
+          } else if (err.message.endsWith(' because they have a trade ban.')) {
+            return reject(new BadRequestException('User is trade banned'));
+          } else if (
+            err.message.startsWith(
+              'This Trade URL is no longer valid for sending a trade offer to ',
+            )
+          ) {
+            return reject(
+              new BadRequestException('Trade offer token is invalid'),
+            );
+          }
+
+          return reject(err);
+        }
+
+        resolve({ me, them });
+      });
     });
   }
 

--- a/libs/dto/src/lib/escrow.ts
+++ b/libs/dto/src/lib/escrow.ts
@@ -1,14 +1,7 @@
 import { ApiProperty } from '@nestjs/swagger';
 import { IsSteamID } from '@tf2-automatic/is-steamid-validator';
 import { Transform, Type } from 'class-transformer';
-import {
-  IsInt,
-  IsOptional,
-  IsString,
-  Max,
-  Min,
-  ValidateIf,
-} from 'class-validator';
+import { IsInt, IsOptional, IsString, Max, Min } from 'class-validator';
 import SteamID from 'steamid';
 
 export class GetEscrowDto {
@@ -18,9 +11,9 @@ export class GetEscrowDto {
     type: String,
     required: false,
   })
+  @IsOptional()
   @IsSteamID()
   @Transform((params) => new SteamID(params.value))
-  @ValidateIf((o) => !o.token || !o.offerId)
   bot?: SteamID;
 
   @ApiProperty({
@@ -29,8 +22,8 @@ export class GetEscrowDto {
     type: String,
     required: false,
   })
+  @IsOptional()
   @IsString()
-  @ValidateIf((o) => !o.bot && !o.offerId)
   token?: string;
 
   @ApiProperty({
@@ -41,7 +34,6 @@ export class GetEscrowDto {
   })
   @IsOptional()
   @IsString()
-  @ValidateIf((o) => !o.bot && !o.token)
   offerId?: string;
 
   @ApiProperty({

--- a/libs/dto/src/lib/escrow.ts
+++ b/libs/dto/src/lib/escrow.ts
@@ -20,7 +20,7 @@ export class GetEscrowDto {
   })
   @IsSteamID()
   @Transform((params) => new SteamID(params.value))
-  @ValidateIf((o) => !o.token)
+  @ValidateIf((o) => !o.token || !o.offerId)
   bot?: SteamID;
 
   @ApiProperty({
@@ -30,8 +30,19 @@ export class GetEscrowDto {
     required: false,
   })
   @IsString()
-  @ValidateIf((o) => !o.bot)
+  @ValidateIf((o) => !o.bot && !o.offerId)
   token?: string;
+
+  @ApiProperty({
+    example: '9106130714',
+    description: 'The ID of an existing trade offer',
+    type: String,
+    required: false,
+  })
+  @IsOptional()
+  @IsString()
+  @ValidateIf((o) => !o.bot && !o.token)
+  offerId?: string;
 
   @ApiProperty({
     description:

--- a/libs/dto/src/lib/trades.ts
+++ b/libs/dto/src/lib/trades.ts
@@ -290,6 +290,7 @@ export class GetExchangeDetailsDto {
 export class GetTradeQueueDto implements GetTradeQueue {
   @ApiProperty({
     description: 'The page number to get',
+    type: 'number',
     example: 1,
     required: false,
   })
@@ -301,6 +302,7 @@ export class GetTradeQueueDto implements GetTradeQueue {
 
   @ApiProperty({
     description: 'The page size to get',
+    type: 'number',
     example: 10,
     required: false,
   })


### PR DESCRIPTION
  ## Summary
  Allows fetching escrow duration for an existing trade offer by passing `offerId`, so callers no longer need a trade token or to be friends with the partner when the offer already exists.

  ## Why
  The previous endpoint required either a `token` or friendship to construct a new offer via `createOffer(steamid, token)` just to read escrow days. For offers that already exist (e.g. incoming offers we
  want to inspect before accepting), this was an unnecessary obstacle — we have the offer ID already and can call `manager.getOffer(offerId)` directly.